### PR TITLE
Add and enable rectangle and polygon draw tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,8 @@ To add a new NPM package to the project:
 
 - Manually add the package to the project's `package.json` file, ensuring that you
 pin it to a specific version.
-- Add the package to the `vendor` array in `webpack.common.config.js`.
 - Run `./scripts/update` in the VM.
 - Commit the changes to the following files to git:
     - `package.json`
     - `yarn.lock`
-    - `webpack.common.config.js`
-
-#### Notes
-
-* We usually pin packages to a specific version to minimize build errors.
-* For packages in the regular/non-dev dependencies section of `package.json`,
-  manually add the package name to the `vendor` array in `webpack.config.json`
+- We usually pin packages to a specific version to minimize build errors.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Friendly front-end for querying OSM features around Guyana and extracting as a S
 Install the application and all required dependencies.
 
 ```sh
-./scripts/setup.sh
+./scripts/setup
 ```
 
 #### Development
@@ -23,8 +23,8 @@ Rebuild Docker images and run application.
 ```sh
 vagrant up
 vagrant ssh
-./scripts/update.sh
-./scripts/server.sh
+./scripts/update
+./scripts/server
 ```
 
 ### Ports
@@ -36,7 +36,7 @@ vagrant ssh
 ### Testing
 
 ```
-./scripts/test.sh
+./scripts/test
 ```
 
 ### Scripts
@@ -48,7 +48,7 @@ vagrant ssh
 | `console`      | Run interactive shell inside application container            |
 | `lint`         | Lint source code                                              |
 | `server`       | Run Docker Compose services                                   |
-| `setup`        | Provision Vagrant VM and run `update.sh`                      |
+| `setup`        | Provision Vagrant VM and run `update`                         |
 | `test`         | Run unit tests                                                |
 | `update`       | Build Docker images                                           |
 

--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import Sidebar from './components/Sidebar';
-import OSMExtractionMap from './components/OSMExtractionMap';
+import LoadableMap from './components/LoadableMap';
 
 export default function App() {
     return (
         <div className="app-container">
             <Sidebar />
-            <OSMExtractionMap />
+            <LoadableMap />
         </div>
     );
 }

--- a/src/app/js/src/actions.js
+++ b/src/app/js/src/actions.js
@@ -1,5 +1,0 @@
-export const INC = 'INC';
-
-export function inc() {
-    return { type: INC };
-}

--- a/src/app/js/src/actions.ui.js
+++ b/src/app/js/src/actions.ui.js
@@ -1,0 +1,29 @@
+export const START_DRAWING_BOX = 'START_DRAWING_BOX';
+export const START_DRAWING_SHAPE = 'START_DRAWING_SHAPE';
+export const CANCEL_DRAWING = 'CANCEL_DRAWING';
+export const COMPLETE_DRAWING = 'COMPLETE_DRAWING';
+
+export function startDrawingBox() {
+    return {
+        type: START_DRAWING_BOX,
+    };
+}
+
+export function startDrawingShape() {
+    return {
+        type: START_DRAWING_SHAPE,
+    };
+}
+
+export function cancelDrawing() {
+    return {
+        type: CANCEL_DRAWING,
+    };
+}
+
+export function completeDrawing(payload) {
+    return {
+        type: COMPLETE_DRAWING,
+        payload,
+    };
+}

--- a/src/app/js/src/components/DrawTools.jsx
+++ b/src/app/js/src/components/DrawTools.jsx
@@ -1,25 +1,110 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+import { bool, func, oneOf } from 'prop-types';
+import { connect } from 'react-redux';
 
-export default function DrawTools() {
+import {
+    startDrawingBox,
+    startDrawingShape,
+    cancelDrawing,
+} from '../actions.ui';
+
+import { drawToolTypeEnum } from '../constants';
+
+function DrawTools({
+    dispatch,
+    drawTool,
+    active,
+}) {
+    const buttons = (() => {
+        if (!active) {
+            return (
+                <Fragment>
+                    <button
+                        className="button -box"
+                        onClick={() => dispatch(startDrawingBox())}
+                    >
+                        BOX
+                    </button>
+                    <button
+                        className="button -shape"
+                        onClick={() => dispatch(startDrawingShape())}
+                    >
+                        SHAPE
+                    </button>
+                </Fragment>
+            );
+        }
+
+        return (
+            <Fragment>
+                <button
+                    className="button -box"
+                    onClick={
+                        drawTool === drawToolTypeEnum.box ?
+                            () => dispatch(cancelDrawing()) :
+                            null
+                    }
+                    disabled={drawTool === drawToolTypeEnum.shape}
+                >
+                    {
+                        drawTool === drawToolTypeEnum.box ?
+                            'CANCEL' :
+                            'BOX'
+                    }
+                </button>
+                <button
+                    className="button -shape"
+                    onClick={
+                        drawTool === drawToolTypeEnum.box ?
+                            () => dispatch(cancelDrawing()) :
+                            null
+                    }
+                    disabled={drawTool === drawToolTypeEnum.box}
+                >
+                    {
+                        drawTool === drawToolTypeEnum.shape ?
+                            'CANCEL' :
+                            'SHAPE'
+                    }
+                </button>
+            </Fragment>
+        );
+    })();
+
     return (
         <div className="draw-tools">
             <div className="label">
                 Draw site boundaries
             </div>
             <div className="buttons">
-                <button
-                    className="button -box"
-                    onClick={() => window.console.log('drawing rectangle')}
-                >
-                    BOX
-                </button>
-                <button
-                    className="button -shape"
-                    onClick={() => window.console.log('drawing shape')}
-                >
-                    SHAPE
-                </button>
+                {buttons}
             </div>
         </div>
     );
 }
+
+DrawTools.defaultProps = {
+    drawTool: null,
+};
+
+DrawTools.propTypes = {
+    dispatch: func.isRequired,
+    drawTool: oneOf(Object.values(drawToolTypeEnum)),
+    active: bool.isRequired,
+};
+
+function mapStateToProps({
+    ui: {
+        drawing: {
+            drawTool,
+            active,
+        },
+    },
+}) {
+    return {
+        drawTool,
+        active,
+    };
+}
+
+export default connect(mapStateToProps)(DrawTools);

--- a/src/app/js/src/components/DrawTools.jsx
+++ b/src/app/js/src/components/DrawTools.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function DrawTools() {
+    return (
+        <div className="draw-tools">
+            <div className="label">
+                Draw site boundaries
+            </div>
+            <div className="buttons">
+                <button
+                    className="button -box"
+                    onClick={() => window.console.log('drawing rectangle')}
+                >
+                    BOX
+                </button>
+                <button
+                    className="button -shape"
+                    onClick={() => window.console.log('drawing shape')}
+                >
+                    SHAPE
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/app/js/src/components/DrawTools.jsx
+++ b/src/app/js/src/components/DrawTools.jsx
@@ -14,8 +14,26 @@ function DrawTools({
     dispatch,
     drawTool,
     active,
+    boundariesConfirmed,
 }) {
+    const drawIcon = <i className="far fa-square" />;
+    const cancelIcon = <i className="far fa-times-circle" />;
+    const checkmarkIcon = <i className="fas fa-check" />;
+
     const buttons = (() => {
+        if (boundariesConfirmed) {
+            return (
+                <button
+                    className="button -confirmed"
+                    onClick={() => dispatch(cancelDrawing())}
+                >
+                    {checkmarkIcon}
+                    Boundaries confirmed
+                    {cancelIcon}
+                </button>
+            );
+        }
+
         if (!active) {
             return (
                 <Fragment>
@@ -23,12 +41,14 @@ function DrawTools({
                         className="button -box"
                         onClick={() => dispatch(startDrawingBox())}
                     >
+                        {drawIcon}
                         BOX
                     </button>
                     <button
                         className="button -shape"
                         onClick={() => dispatch(startDrawingShape())}
                     >
+                        {drawIcon}
                         SHAPE
                     </button>
                 </Fragment>
@@ -48,6 +68,11 @@ function DrawTools({
                 >
                     {
                         drawTool === drawToolTypeEnum.box ?
+                            cancelIcon :
+                            drawIcon
+                    }
+                    {
+                        drawTool === drawToolTypeEnum.box ?
                             'CANCEL' :
                             'BOX'
                     }
@@ -55,12 +80,17 @@ function DrawTools({
                 <button
                     className="button -shape"
                     onClick={
-                        drawTool === drawToolTypeEnum.box ?
+                        drawTool === drawToolTypeEnum.shape ?
                             () => dispatch(cancelDrawing()) :
                             null
                     }
                     disabled={drawTool === drawToolTypeEnum.box}
                 >
+                    {
+                        drawTool === drawToolTypeEnum.shape ?
+                            cancelIcon :
+                            drawIcon
+                    }
                     {
                         drawTool === drawToolTypeEnum.shape ?
                             'CANCEL' :
@@ -91,6 +121,7 @@ DrawTools.propTypes = {
     dispatch: func.isRequired,
     drawTool: oneOf(Object.values(drawToolTypeEnum)),
     active: bool.isRequired,
+    boundariesConfirmed: bool.isRequired,
 };
 
 function mapStateToProps({
@@ -98,12 +129,14 @@ function mapStateToProps({
         drawing: {
             drawTool,
             active,
+            drawnShape,
         },
     },
 }) {
     return {
         drawTool,
         active,
+        boundariesConfirmed: !!drawnShape,
     };
 }
 

--- a/src/app/js/src/components/DrawTools.jsx
+++ b/src/app/js/src/components/DrawTools.jsx
@@ -16,7 +16,8 @@ function DrawTools({
     active,
     boundariesConfirmed,
 }) {
-    const drawIcon = <i className="far fa-square" />;
+    const drawBoxIcon = <i className="far fa-square" />;
+    const drawShapeIcon = <i className="far fa-star" />;
     const cancelIcon = <i className="far fa-times-circle" />;
     const checkmarkIcon = <i className="fas fa-check" />;
 
@@ -41,14 +42,14 @@ function DrawTools({
                         className="button -box"
                         onClick={() => dispatch(startDrawingBox())}
                     >
-                        {drawIcon}
+                        {drawBoxIcon}
                         BOX
                     </button>
                     <button
                         className="button -shape"
                         onClick={() => dispatch(startDrawingShape())}
                     >
-                        {drawIcon}
+                        {drawShapeIcon}
                         SHAPE
                     </button>
                 </Fragment>
@@ -69,7 +70,7 @@ function DrawTools({
                     {
                         drawTool === drawToolTypeEnum.box ?
                             cancelIcon :
-                            drawIcon
+                            drawBoxIcon
                     }
                     {
                         drawTool === drawToolTypeEnum.box ?
@@ -89,7 +90,7 @@ function DrawTools({
                     {
                         drawTool === drawToolTypeEnum.shape ?
                             cancelIcon :
-                            drawIcon
+                            drawShapeIcon
                     }
                     {
                         drawTool === drawToolTypeEnum.shape ?

--- a/src/app/js/src/components/LoadableMap.jsx
+++ b/src/app/js/src/components/LoadableMap.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Loadable from 'react-loadable';
+
+import Loading from './Loading';
+
+const LoadableComponent = Loadable({
+    loader: () => import('./OSMExtractionMap.jsx'),
+    loading: Loading,
+});
+
+export default function LoadableMap() {
+    return <LoadableComponent />;
+}

--- a/src/app/js/src/components/Loading.jsx
+++ b/src/app/js/src/components/Loading.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Loading() {
+    return (
+        <div className="loading">
+            <i className="fa fa-circle-o-notch fa-spin" />
+        </div>
+    );
+}

--- a/src/app/js/src/components/OSMExtractionMap.jsx
+++ b/src/app/js/src/components/OSMExtractionMap.jsx
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
-import { bool, func, oneOf } from 'prop-types';
+import { bool, func, object, oneOf } from 'prop-types';
 import { connect } from 'react-redux';
 import {
     Map as ReactLeafletMap,
     TileLayer,
     ZoomControl,
+    GeoJSON,
 } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet-draw';
@@ -18,6 +19,7 @@ import {
     initialMapCenter,
     initialMapZoom,
     drawToolTypeEnum,
+    areaOfInterestStyle,
 } from '../constants';
 
 
@@ -44,8 +46,13 @@ class OSMExtractionMap extends Component {
             this.handleDrawAreaOfInterest,
         );
 
-        this.rectangleDrawHandler = new L.Draw.Rectangle(leafletElement);
-        this.polygonDrawHandler = new L.Draw.Polygon(leafletElement);
+        this.rectangleDrawHandler = new L.Draw.Rectangle(leafletElement, {
+            shapeOptions: areaOfInterestStyle,
+        });
+
+        this.polygonDrawHandler = new L.Draw.Polygon(leafletElement, {
+            shapeOptions: areaOfInterestStyle,
+        });
     }
 
     componentDidUpdate({ drawingActive: drawingWasActive }) {
@@ -83,6 +90,16 @@ class OSMExtractionMap extends Component {
     }
 
     render() {
+        const {
+            drawnShape,
+        } = this.props;
+
+        const areaOfInterest = drawnShape ? (
+            <GeoJSON
+                data={drawnShape}
+                style={areaOfInterestStyle}
+            />) : null;
+
         return (
             <ReactLeafletMap
                 id="osm-extraction-map"
@@ -97,6 +114,7 @@ class OSMExtractionMap extends Component {
                     maxZoom={basemapMaxZoom}
                 />
                 <ZoomControl position="topright" />
+                {areaOfInterest}
             </ReactLeafletMap>
         );
     }
@@ -104,11 +122,13 @@ class OSMExtractionMap extends Component {
 
 OSMExtractionMap.defaultProps = {
     drawTool: null,
+    drawnShape: null,
 };
 
 OSMExtractionMap.propTypes = {
     dispatch: func.isRequired,
     drawTool: oneOf(Object.values(drawToolTypeEnum)),
+    drawnShape: object, // eslint-disable-line react/forbid-prop-types
     drawingActive: bool.isRequired,
 };
 
@@ -117,12 +137,14 @@ function mapStateToProps({
         drawing: {
             drawTool,
             active: drawingActive,
+            drawnShape,
         },
     },
 }) {
     return {
         drawTool,
         drawingActive,
+        drawnShape,
     };
 }
 

--- a/src/app/js/src/components/OSMExtractionMap.jsx
+++ b/src/app/js/src/components/OSMExtractionMap.jsx
@@ -10,7 +10,10 @@ import {
 import L from 'leaflet';
 import 'leaflet-draw';
 
-import { completeDrawing } from '../actions.ui';
+import {
+    cancelDrawing,
+    completeDrawing,
+} from '../actions.ui';
 
 import {
     basemapTilesUrl,
@@ -27,6 +30,7 @@ class OSMExtractionMap extends Component {
     constructor(props) {
         super(props);
         this.handleDrawAreaOfInterest = this.handleDrawAreaOfInterest.bind(this);
+        this.handleCancelDrawing = this.handleCancelDrawing.bind(this);
     }
 
     componentDidMount() {
@@ -37,8 +41,8 @@ class OSMExtractionMap extends Component {
         } = this;
 
         leafletElement.on(
-            L.Draw.Event.DRAWSTART,
-            () => { window.console.log('started drawing!'); },
+            L.Draw.Event.DRAWSTOP,
+            this.handleCancelDrawing,
         );
 
         leafletElement.on(
@@ -87,6 +91,12 @@ class OSMExtractionMap extends Component {
 
     handleDrawAreaOfInterest({ layer }) {
         return this.props.dispatch(completeDrawing(layer.toGeoJSON()));
+    }
+
+    handleCancelDrawing() {
+        return !this.props.drawnShape ?
+            this.props.dispatch(cancelDrawing()) :
+            null;
     }
 
     render() {

--- a/src/app/js/src/components/OSMExtractionMap.jsx
+++ b/src/app/js/src/components/OSMExtractionMap.jsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, { Component } from 'react';
+import { bool, func, oneOf } from 'prop-types';
+import { connect } from 'react-redux';
 import {
     Map as ReactLeafletMap,
     TileLayer,
     ZoomControl,
 } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet-draw';
+
+import { completeDrawing } from '../actions.ui';
 
 import {
     basemapTilesUrl,
@@ -11,22 +17,113 @@ import {
     basemapMaxZoom,
     initialMapCenter,
     initialMapZoom,
+    drawToolTypeEnum,
 } from '../constants';
 
-export default function OSMExtractionMap() {
-    return (
-        <ReactLeafletMap
-            id="osm-extraction-map"
-            center={initialMapCenter}
-            zoom={initialMapZoom}
-            zoomControl={false}
-        >
-            <TileLayer
-                url={basemapTilesUrl}
-                attribution={basemapAttribution}
-                maxZoom={basemapMaxZoom}
-            />
-            <ZoomControl position="topright" />
-        </ReactLeafletMap>
-    );
+
+class OSMExtractionMap extends Component {
+    constructor(props) {
+        super(props);
+        this.handleDrawAreaOfInterest = this.handleDrawAreaOfInterest.bind(this);
+    }
+
+    componentDidMount() {
+        const {
+            leafletMap: {
+                leafletElement,
+            },
+        } = this;
+
+        leafletElement.on(
+            L.Draw.Event.DRAWSTART,
+            () => { window.console.log('started drawing!'); },
+        );
+
+        leafletElement.on(
+            L.Draw.Event.CREATED,
+            this.handleDrawAreaOfInterest,
+        );
+
+        this.rectangleDrawHandler = new L.Draw.Rectangle(leafletElement);
+        this.polygonDrawHandler = new L.Draw.Polygon(leafletElement);
+    }
+
+    componentDidUpdate({ drawingActive: drawingWasActive }) {
+        const {
+            drawTool,
+            drawingActive,
+        } = this.props;
+
+        if (drawingActive === drawingWasActive) {
+            return null;
+        }
+
+        if (drawingActive) {
+            switch (drawTool) {
+                case drawToolTypeEnum.box:
+                    this.rectangleDrawHandler.enable();
+                    break;
+                case drawToolTypeEnum.shape:
+                    this.polygonDrawHandler.enable();
+                    break;
+                default:
+                    window.console.warn('invalid draw tool type');
+                    break;
+            }
+        } else {
+            this.polygonDrawHandler.disable();
+            this.rectangleDrawHandler.disable();
+        }
+
+        return null;
+    }
+
+    handleDrawAreaOfInterest({ layer }) {
+        return this.props.dispatch(completeDrawing(layer.toGeoJSON()));
+    }
+
+    render() {
+        return (
+            <ReactLeafletMap
+                id="osm-extraction-map"
+                ref={(m) => { this.leafletMap = m; }}
+                center={initialMapCenter}
+                zoom={initialMapZoom}
+                zoomControl={false}
+            >
+                <TileLayer
+                    url={basemapTilesUrl}
+                    attribution={basemapAttribution}
+                    maxZoom={basemapMaxZoom}
+                />
+                <ZoomControl position="topright" />
+            </ReactLeafletMap>
+        );
+    }
 }
+
+OSMExtractionMap.defaultProps = {
+    drawTool: null,
+};
+
+OSMExtractionMap.propTypes = {
+    dispatch: func.isRequired,
+    drawTool: oneOf(Object.values(drawToolTypeEnum)),
+    drawingActive: bool.isRequired,
+};
+
+function mapStateToProps({
+    ui: {
+        drawing: {
+            drawTool,
+            active: drawingActive,
+        },
+    },
+}) {
+    return {
+        drawTool,
+        drawingActive,
+    };
+}
+
+export default connect(mapStateToProps)(OSMExtractionMap);

--- a/src/app/js/src/components/Sidebar.jsx
+++ b/src/app/js/src/components/Sidebar.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
 import Header from './Header';
+import DrawTools from './DrawTools';
 import ExtractButton from './ExtractButton';
 
 export default function Sidebar() {
     return (
         <div className="sidebar">
             <Header />
+            <DrawTools />
             <ExtractButton />
         </div>
     );

--- a/src/app/js/src/constants.js
+++ b/src/app/js/src/constants.js
@@ -8,3 +8,8 @@ export const initialMapCenter = [
     -58.9302,
 ];
 export const initialMapZoom = 7;
+
+export const drawToolTypeEnum = {
+    box: 'box',
+    shape: 'shape',
+};

--- a/src/app/js/src/constants.js
+++ b/src/app/js/src/constants.js
@@ -13,3 +13,10 @@ export const drawToolTypeEnum = {
     box: 'box',
     shape: 'shape',
 };
+
+export const areaOfInterestStyle = {
+    color: '#0A393C',
+    fill: false,
+    opacity: 1.0,
+    weight: 3,
+};

--- a/src/app/js/src/reducers.data.js
+++ b/src/app/js/src/reducers.data.js
@@ -1,0 +1,8 @@
+const initialState = {};
+
+export default function dataReducer(state = initialState, { type }) {
+    switch (type) {
+        default:
+            return state;
+    }
+}

--- a/src/app/js/src/reducers.js
+++ b/src/app/js/src/reducers.js
@@ -1,22 +1,9 @@
 import { combineReducers } from 'redux';
 
-import { INC } from './actions';
-
-const initialState = {
-    n: 0,
-};
-
-function mainReducer(state = initialState, action) {
-    switch (action.type) {
-        case INC:
-            return Object.assign({}, state, {
-                n: state.n + 1,
-            });
-        default:
-            return state;
-    }
-}
+import uiReducer from './reducers.ui';
+import dataReducer from './reducers.data';
 
 export default combineReducers({
-    main: mainReducer,
+    ui: uiReducer,
+    data: dataReducer,
 });

--- a/src/app/js/src/reducers.ui.js
+++ b/src/app/js/src/reducers.ui.js
@@ -1,0 +1,58 @@
+import {
+    START_DRAWING_BOX,
+    START_DRAWING_SHAPE,
+    CANCEL_DRAWING,
+    COMPLETE_DRAWING,
+} from './actions.ui';
+
+import { drawToolTypeEnum } from './constants';
+
+const initialState = {
+    drawing: {
+        drawTool: null,
+        active: false,
+        drawnShape: null,
+    },
+};
+
+export default function uiReducer(state = initialState, { type, payload }) {
+    switch (type) {
+        case START_DRAWING_BOX:
+            return {
+                ...state,
+                drawing: {
+                    ...state.drawing,
+                    drawTool: drawToolTypeEnum.box,
+                    active: true,
+                    drawnShape: null,
+                },
+            };
+        case START_DRAWING_SHAPE:
+            return {
+                ...state,
+                drawing: {
+                    ...state.drawing,
+                    drawTool: drawToolTypeEnum.shape,
+                    active: true,
+                    drawnShape: null,
+                },
+            };
+        case COMPLETE_DRAWING:
+            return {
+                ...state,
+                drawing: {
+                    ...state.drawing,
+                    drawTool: null,
+                    active: false,
+                    drawnShape: payload,
+                },
+            };
+        case CANCEL_DRAWING:
+            return {
+                ...state,
+                drawing: initialState.drawing,
+            };
+        default:
+            return state;
+    }
+}

--- a/src/app/js/src/store.js
+++ b/src/app/js/src/store.js
@@ -2,14 +2,8 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
 
-const middlewares = [thunk];
+const middleware = process.env.NODE_ENV === 'development' ?
+    [thunk, createLogger()] :
+    [thunk];
 
-if (process.env.NODE_ENV === 'development') {
-    const logger = createLogger();
-    middlewares.push(logger);
-}
-
-const createStoreWithMiddleware =
-    applyMiddleware(...middlewares)(createStore);
-
-export { createStoreWithMiddleware as default };
+export default applyMiddleware(...middleware)(createStore);

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "axios": "~0.18.0",
     "leaflet": "~1.3.1",
+    "leaflet-draw": "~0.4.14",
     "prop-types": "~15.6.1",
     "react": "~16.3.1",
     "react-dom": "~16.3.1",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -28,6 +28,7 @@
     "react-dom": "~16.3.1",
     "react-hot-loader": "~4.0.1",
     "react-leaflet": "~1.9.1",
+    "react-loadable": "~5.4.0",
     "react-redux": "~5.0.7",
     "react-router": "~4.2.0",
     "react-router-dom": "~4.2.2",

--- a/src/app/sass/loading.scss
+++ b/src/app/sass/loading.scss
@@ -1,0 +1,11 @@
+.loading {
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    width: 100%;
+    height: 100%;
+
+    > .fa-spin {
+        align-self: center;
+    }
+}

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -1,4 +1,5 @@
 @import "../node_modules/leaflet/dist/leaflet.css";
+@import "../node_modules/leaflet-draw/dist/leaflet.draw.css";
 @import "variables.scss";
 @import "app.scss";
 @import "map.scss";

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -2,5 +2,6 @@
 @import "../node_modules/leaflet-draw/dist/leaflet.draw.css";
 @import "variables.scss";
 @import "app.scss";
+@import "loading.scss";
 @import "map.scss";
 @import "sidebar.scss";

--- a/src/app/sass/sidebar.scss
+++ b/src/app/sass/sidebar.scss
@@ -42,6 +42,10 @@
                 font-size: 1.3rem;
                 height: 3.5rem;
                 width: 45%;
+
+                &.-active {
+                    width: 100% !important;
+                }
             }
         }
     }

--- a/src/app/sass/sidebar.scss
+++ b/src/app/sass/sidebar.scss
@@ -19,6 +19,33 @@
         }
     }
 
+    > .draw-tools {
+        align-self: center;
+        width: 80%;
+        flex: 2;
+        margin-top: 2rem;
+
+        > .label {
+            margin-bottom: 0.5rem;
+        }
+
+        > .buttons {
+            display: flex;
+            justify-content: space-between;
+
+            > .button {
+                border: none;
+                margin-bottom: 2rem;
+                align-self: center;
+                background-color: $buttongray;
+                color: $black;
+                font-size: 1.3rem;
+                height: 3.5rem;
+                width: 45%;
+            }
+        }
+    }
+
     > .button {
         &.-extract {
             border: none;

--- a/src/app/sass/sidebar.scss
+++ b/src/app/sass/sidebar.scss
@@ -42,8 +42,11 @@
                 font-size: 1.3rem;
                 height: 3.5rem;
                 width: 45%;
+                display: flex;
+                justify-content: space-around;
+                align-items: center;
 
-                &.-active {
+                &.-confirmed {
                     width: 100% !important;
                 }
             }

--- a/src/app/template.html
+++ b/src/app/template.html
@@ -5,6 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta content="IE=edge" http-equiv="X-UA-Compatible">
         <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
+        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
     </head>
     <body>
         <div id="root"></div>

--- a/src/app/webpack.common.config.js
+++ b/src/app/webpack.common.config.js
@@ -41,7 +41,11 @@ module.exports = {
                 loader: 'babel-loader',
                 query: {
                     presets: ['env', 'react'],
-                    plugins: ['react-hot-loader/babel', 'transform-object-assign'],
+                    plugins: [
+                        'react-hot-loader/babel',
+                        'transform-object-assign',
+                        'transform-object-rest-spread',
+                    ],
                 },
             },
             {

--- a/src/app/webpack.common.config.js
+++ b/src/app/webpack.common.config.js
@@ -7,19 +7,6 @@ var outputPath = '/usr/dist';
 module.exports = {
     entry: {
         app: ['babel-polyfill', './js/src/main.jsx'],
-        vendor: [
-            'axios',
-            'leaflet',
-            'react',
-            'react-dom',
-            'react-leaflet',
-            'react-redux',
-            'react-router',
-            'react-router-dom',
-            'redux',
-            'redux-logger',
-            'redux-thunk',
-        ],
     },
     output: {
         path: outputPath,
@@ -43,6 +30,7 @@ module.exports = {
                     presets: ['env', 'react'],
                     plugins: [
                         'react-hot-loader/babel',
+                        'syntax-dynamic-import',
                         'transform-object-assign',
                         'transform-object-rest-spread',
                     ],
@@ -61,17 +49,17 @@ module.exports = {
                     },
                     {
                         loader: 'css-loader'
-                    }, 
+                    },
                     {
                         loader: 'resolve-url-loader'
-                    }, 
+                    },
                     {
                         loader: 'postcss-loader',
                         options: {
                             sourceMap: true,
                             plugins: () => [require('autoprefixer')]
                         }
-                    }, 
+                    },
                     {
                         loader: 'sass-loader?sourceMap'
                     }
@@ -97,9 +85,15 @@ module.exports = {
             {
                 test: require.resolve('leaflet'),
                 use: [
-                    'expose-loader?L',
-                    'expose-loader?leaflet'
-                ]
+                    {
+                        loader: 'expose-loader',
+                        query: 'leaflet',
+                    },
+                    {
+                        loader: 'expose-loader',
+                        query: 'L',
+                    },
+                ],
             },
         ],
     },

--- a/src/app/webpack.prod.config.js
+++ b/src/app/webpack.prod.config.js
@@ -10,15 +10,13 @@ config.plugins.push(
             NODE_ENV: JSON.stringify('production'),
         },
     }),
-    new webpack.optimize.UglifyJsPlugin({
-        compress: {
-            warnings: false,
-        },
-        sourceMap: true
-    }),
     new webpack.LoaderOptionsPlugin({
         minimize: true
     })
 );
+
+config.optimization = {
+    minimize: true,
+};
 
 module.exports = config;

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -5965,6 +5965,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@~15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
@@ -6140,6 +6147,12 @@ react-leaflet@~1.9.1:
     lodash "^4.0.0"
     lodash-es "^4.0.0"
     warning "^3.0.0"
+
+react-loadable@~5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-5.4.0.tgz#3b6b7d51121a7868fd155be848a36e02084742c9"
+  dependencies:
+    prop-types "^15.5.0"
 
 react-redux@~5.0.7:
   version "5.0.7"

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -4416,6 +4416,10 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+leaflet-draw@~0.4.14:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/leaflet-draw/-/leaflet-draw-0.4.14.tgz#1b5b06d570873a015aa96b80d664dab496c45a4a"
+
 leaflet@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.3.1.tgz#86f336d2fb0e2d0ff446677049a5dc34cf0ea60e"


### PR DESCRIPTION
## Overview

This PR adds and enables the draw tool buttons. It also fixes the `cibuild` script and makes some updates to the webpack-config to use react-loadable so that we can split the code and make the output bundles smaller.

Connects #3

### Demo

![drawtools](https://user-images.githubusercontent.com/4165523/42826416-55268fa6-89b2-11e8-9aca-2fe924b5dbd2.gif)

cibuild output:

```
Hash: 5368cfb43977c084e85e                                                                                         
Version: webpack 4.5.0                                                                                             
Time: 12776ms                                                                                                      
Built at: 2018-7-17 15:07:50                                                                                       
                             Asset       Size  Chunks                    Chunk Names                               
  0.bundle.5368cfb43977c084e85e.js    273 KiB       0  [emitted]  [big]                                            
  1.bundle.5368cfb43977c084e85e.js   3.03 KiB       1  [emitted]                                                   
app.bundle.5368cfb43977c084e85e.js    319 KiB       2  [emitted]  [big]  app                                       
                        index.html  569 bytes          [emitted]                                                   
Entrypoint app [big] = app.bundle.5368cfb43977c084e85e.js                                                          
  [51] (webpack)/buildin/global.js 509 bytes {2} [built]                        
```

## Notes

I used some font-awesome icons in places where the wireframes indicated there should be icons. 

Unfortunately the freely available FA icons don't map exactly onto what was depicted in the wireframes -- notably, I couldn't find a shape that wasn't square, let alone pentagonal, for the "Shape" button.

## Testing

- get, build, and serve this branch to check that the draw tools work both in Chrome and IE11
- run `./scripts/cibuild`, then serve that output and check that the draw tools work for that version in both Chrome and IE11