### PR TITLE
Add select filters

### DIFF
--- a/src/app/js/src/actions.ui.js
+++ b/src/app/js/src/actions.ui.js
@@ -2,6 +2,8 @@ export const START_DRAWING_BOX = 'START_DRAWING_BOX';
 export const START_DRAWING_SHAPE = 'START_DRAWING_SHAPE';
 export const CANCEL_DRAWING = 'CANCEL_DRAWING';
 export const COMPLETE_DRAWING = 'COMPLETE_DRAWING';
+export const SELECT_DATE_RANGE = 'SELECT_DATE_RANGE';
+export const SELECT_FEATURES = 'SELECT_FEATURES';
 
 export function startDrawingBox() {
     return {
@@ -24,6 +26,20 @@ export function cancelDrawing() {
 export function completeDrawing(payload) {
     return {
         type: COMPLETE_DRAWING,
+        payload,
+    };
+}
+
+export function selectDateRange(payload) {
+    return {
+        type: SELECT_DATE_RANGE,
+        payload,
+    };
+}
+
+export function selectFeatures(payload) {
+    return {
+        type: SELECT_FEATURES,
         payload,
     };
 }

--- a/src/app/js/src/components/DateRangeSelector.jsx
+++ b/src/app/js/src/components/DateRangeSelector.jsx
@@ -24,7 +24,7 @@ function DateRangeSelector({
                 value={dateRange}
                 options={dateRangeOptions}
                 clearable={false}
-                placeholder="Choose a date range of map data..."
+                placeholder="Choose a date range..."
             />
             <div className="subscript">
                 (optional)

--- a/src/app/js/src/components/DateRangeSelector.jsx
+++ b/src/app/js/src/components/DateRangeSelector.jsx
@@ -1,9 +1,18 @@
 import React from 'react';
+import { func, oneOf } from 'prop-types';
+import { connect } from 'react-redux';
 import Select from 'react-select';
+
+import { selectDateRange } from '../actions.ui';
 
 import { dateRangeOptions } from '../constants';
 
-export default function DateRangeSelector() {
+function DateRangeSelector({
+    dateRange,
+    dispatch,
+}) {
+    const handleSelectDateRange = ({ value }) => dispatch(selectDateRange(value));
+
     return (
         <div className="select -date">
             <div className="label">
@@ -11,8 +20,11 @@ export default function DateRangeSelector() {
             </div>
             <Select
                 name="date-range-selector"
-                value={null}
+                onChange={handleSelectDateRange}
+                value={dateRange}
                 options={dateRangeOptions}
+                clearable={false}
+                placeholder="Choose a date range of map data..."
             />
             <div className="subscript">
                 (optional)
@@ -20,3 +32,26 @@ export default function DateRangeSelector() {
         </div>
     );
 }
+
+DateRangeSelector.defaultProps = {
+    dateRange: null,
+};
+
+DateRangeSelector.propTypes = {
+    dateRange: oneOf(dateRangeOptions.map(({ value }) => value)),
+    dispatch: func.isRequired,
+};
+
+function mapStateToProps({
+    ui: {
+        filters: {
+            dateRange,
+        },
+    },
+}) {
+    return {
+        dateRange,
+    };
+}
+
+export default connect(mapStateToProps)(DateRangeSelector);

--- a/src/app/js/src/components/DateRangeSelector.jsx
+++ b/src/app/js/src/components/DateRangeSelector.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Select from 'react-select';
+
+import { dateRangeOptions } from '../constants';
+
+export default function DateRangeSelector() {
+    return (
+        <div className="select -date">
+            <div className="label">
+                Date range
+            </div>
+            <Select
+                name="date-range-selector"
+                value={null}
+                options={dateRangeOptions}
+            />
+            <div className="subscript">
+                (optional)
+            </div>
+        </div>
+    );
+}

--- a/src/app/js/src/components/FeatureSelector.jsx
+++ b/src/app/js/src/components/FeatureSelector.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Select from 'react-select';
+
+import { featureOptions } from '../constants';
+
+export default function FeatureSelector() {
+    return (
+        <div className="select -feature">
+            <div className="label">
+                Feature
+            </div>
+            <Select
+                name="feature-selector"
+                value={null}
+                options={featureOptions}
+            />
+        </div>
+    );
+}

--- a/src/app/js/src/components/FeatureSelector.jsx
+++ b/src/app/js/src/components/FeatureSelector.jsx
@@ -1,9 +1,18 @@
 import React from 'react';
+import { func, oneOf } from 'prop-types';
+import { connect } from 'react-redux';
 import Select from 'react-select';
+
+import { selectFeatures } from '../actions.ui';
 
 import { featureOptions } from '../constants';
 
-export default function FeatureSelector() {
+function FeatureSelector({
+    features,
+    dispatch,
+}) {
+    const handleSelectFeaturesChange = ({ value }) => dispatch(selectFeatures(value));
+
     return (
         <div className="select -feature">
             <div className="label">
@@ -11,9 +20,35 @@ export default function FeatureSelector() {
             </div>
             <Select
                 name="feature-selector"
-                value={null}
+                onChange={handleSelectFeaturesChange}
+                value={features}
                 options={featureOptions}
+                clearable={false}
+                placeholder="Select a feature to extract..."
             />
         </div>
     );
 }
+
+FeatureSelector.defaultProps = {
+    features: null,
+};
+
+FeatureSelector.propTypes = {
+    features: oneOf(featureOptions.map(({ value }) => value)),
+    dispatch: func.isRequired,
+};
+
+function mapStateToProps({
+    ui: {
+        filters: {
+            features,
+        },
+    },
+}) {
+    return {
+        features,
+    };
+}
+
+export default connect(mapStateToProps)(FeatureSelector);

--- a/src/app/js/src/components/Sidebar.jsx
+++ b/src/app/js/src/components/Sidebar.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import Header from './Header';
 import DrawTools from './DrawTools';
+import FeatureSelector from './FeatureSelector';
+import DateRangeSelector from './DateRangeSelector';
 import ExtractButton from './ExtractButton';
 
 export default function Sidebar() {
@@ -9,6 +11,10 @@ export default function Sidebar() {
         <div className="sidebar">
             <Header />
             <DrawTools />
+            <div className="filters">
+                <FeatureSelector />
+                <DateRangeSelector />
+            </div>
             <ExtractButton />
         </div>
     );

--- a/src/app/js/src/constants.js
+++ b/src/app/js/src/constants.js
@@ -20,3 +20,49 @@ export const areaOfInterestStyle = {
     opacity: 1.0,
     weight: 3,
 };
+
+export const featureOptions = [
+    {
+        value: 'buildings',
+        label: 'Buildings',
+    },
+    {
+        value: 'emergencyInfraStructure',
+        label: 'Emergency infrastructure',
+    },
+    {
+        value: 'powerInfrastructure',
+        label: 'Power infrastructure',
+    },
+    {
+        value: 'roads',
+        label: 'Roads',
+    },
+    {
+        value: 'waterways',
+        label: 'Waterways',
+    },
+    {
+        value: 'airports',
+        label: 'Airports',
+    },
+];
+
+export const dateRangeOptions = [
+    {
+        value: 'all',
+        label: 'All',
+    },
+    {
+        value: 'pastMonth',
+        label: 'Past month',
+    },
+    {
+        value: 'pastThreeMonths',
+        label: 'Past 3 months',
+    },
+    {
+        value: 'pastYear',
+        label: 'Past year',
+    },
+];

--- a/src/app/js/src/reducers.ui.js
+++ b/src/app/js/src/reducers.ui.js
@@ -3,6 +3,8 @@ import {
     START_DRAWING_SHAPE,
     CANCEL_DRAWING,
     COMPLETE_DRAWING,
+    SELECT_DATE_RANGE,
+    SELECT_FEATURES,
 } from './actions.ui';
 
 import { drawToolTypeEnum } from './constants';
@@ -12,6 +14,10 @@ const initialState = {
         drawTool: null,
         active: false,
         drawnShape: null,
+    },
+    filters: {
+        dateRange: null,
+        features: null,
     },
 };
 
@@ -51,6 +57,22 @@ export default function uiReducer(state = initialState, { type, payload }) {
             return {
                 ...state,
                 drawing: initialState.drawing,
+            };
+        case SELECT_DATE_RANGE:
+            return {
+                ...state,
+                filters: {
+                    ...state.filters,
+                    dateRange: payload,
+                },
+            };
+        case SELECT_FEATURES:
+            return {
+                ...state,
+                filters: {
+                    ...state.filters,
+                    features: payload,
+                },
             };
         default:
             return state;

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -32,6 +32,7 @@
     "react-redux": "~5.0.7",
     "react-router": "~4.2.0",
     "react-router-dom": "~4.2.2",
+    "react-select": "~1.2.0",
     "redux": "~3.7.2",
     "redux-logger": "~3.0.6",
     "redux-thunk": "~2.2.0"

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -1,5 +1,6 @@
 @import "../node_modules/leaflet/dist/leaflet.css";
 @import "../node_modules/leaflet-draw/dist/leaflet.draw.css";
+@import '../node_modules/react-select/dist/react-select.css';
 @import "variables.scss";
 @import "app.scss";
 @import "loading.scss";

--- a/src/app/sass/sidebar.scss
+++ b/src/app/sass/sidebar.scss
@@ -25,7 +25,8 @@
         margin-top: 2rem;
 
         > .label {
-            margin-bottom: 0.5rem;
+            margin-bottom: 1rem;
+            font-weight: 700;
         }
 
         > .buttons {
@@ -66,6 +67,7 @@
 
             > .label {
                 margin-bottom: 1rem;
+                font-weight: 700;
             }
 
             > .subscript {

--- a/src/app/sass/sidebar.scss
+++ b/src/app/sass/sidebar.scss
@@ -22,7 +22,6 @@
     > .draw-tools {
         align-self: center;
         width: 80%;
-        flex: 2;
         margin-top: 2rem;
 
         > .label {
@@ -54,7 +53,7 @@
     }
 
     > .filters {
-        flex: 7;
+        flex: 2;
         display: flex;
         flex-direction: column;
 

--- a/src/app/sass/sidebar.scss
+++ b/src/app/sass/sidebar.scss
@@ -53,6 +53,31 @@
         }
     }
 
+    > .filters {
+        flex: 7;
+        display: flex;
+        flex-direction: column;
+
+        > .select {
+            width: 80%;
+            align-self: center;
+            margin: 1rem;
+            display: flex;
+            flex-direction: column;
+
+            > .label {
+                margin-bottom: 1rem;
+            }
+
+            > .subscript {
+                margin-top: 0.5rem;
+                display: flex;
+                flex-direction: row;
+                justify-content: flex-end;
+            }
+        }
+    }
+
     > .button {
         &.-extract {
             border: none;

--- a/src/app/template.html
+++ b/src/app/template.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta content="IE=edge" http-equiv="X-UA-Compatible">
-        <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
     </head>
     <body>

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -1636,6 +1636,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.4:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 clean-css@4.1.x:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
@@ -5965,7 +5969,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.0:
+prop-types@^15.5.0, prop-types@^15.5.8:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -6140,6 +6144,12 @@ react-hot-loader@~4.0.1:
     prop-types "^15.6.1"
     shallowequal "^1.0.2"
 
+react-input-autosize@^2.1.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-leaflet@~1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-1.9.1.tgz#0a282d8d26f66ea2d719ebb8f4a5fa156b33b8c8"
@@ -6187,6 +6197,14 @@ react-router@^4.2.0, react-router@~4.2.0:
     path-to-regexp "^1.7.0"
     prop-types "^15.5.4"
     warning "^3.0.0"
+
+react-select@~1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.2.1.tgz#a2fe58a569eb14dcaa6543816260b97e538120d1"
+  dependencies:
+    classnames "^2.2.4"
+    prop-types "^15.5.8"
+    react-input-autosize "^2.1.2"
 
 react@~16.3.1:
   version "16.3.1"


### PR DESCRIPTION
## Overview

This PR adds the select filters to the sidebar & connects them to Redux. Also did some minor styling in passing to keep closeish to the wireframes.

Only the last 3 commits are from this PR.

Connects #4

### Demo

![select-dropdowns](https://user-images.githubusercontent.com/4165523/42832290-c5a55cb0-89be-11e8-9f2d-a29140517ca2.gif)

![screen shot 2018-07-17 at 12 45 24 pm](https://user-images.githubusercontent.com/4165523/42832479-562466be-89bf-11e8-9eb5-9694910f8720.png)

## Notes

The logic for these two filters is similar enough that in theory they could just be one component configured by different props. Going to leave them as separate for now, but in the future we may want to consolidate them.

## Testing Instructions

- get branch, then `update` and server
- check the app on 4567 in both Chrome and IE11 and verify that the select dropdowns work as depicted above -- making a selection should be reflected in the dropdown and in the Redux state
