### PR TITLE
Create stock overpass query using drawn shape

### DIFF
--- a/src/app/js/src/actions.data.js
+++ b/src/app/js/src/actions.data.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import osmtogeojson from 'osmtogeojson';
 
 import { overpassAPIurl } from './constants';
 import { createOverpassAPIRequestFormData } from './utils';
@@ -62,7 +63,8 @@ export function makeOverpassAPIRequest() {
                 },
             },
         })
-            .then(({ data }) => dispatch(completeOverpassRequest(data)))
+            .then(({ data }) => osmtogeojson(data))
+            .then(data => dispatch(completeOverpassRequest(data)))
             .catch(e => dispatch(failOverpassRequest(e)));
     };
 }

--- a/src/app/js/src/actions.data.js
+++ b/src/app/js/src/actions.data.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import osmtogeojson from 'osmtogeojson';
 
 import { overpassAPIurl } from './constants';
-import { createOverpassAPIRequestFormData } from './utils';
+import createOverpassAPIRequestFormData from './utils';
 
 export const START_OVERPASS_REQUEST = 'START_OVERPASS_REQUEST';
 export const FAIL_OVERPASS_REQUEST = 'FAIL_OVERPASS_REQUEST';
@@ -46,6 +46,10 @@ export function makeOverpassAPIRequest() {
                 },
             },
         } = getState();
+
+        if (!drawnShape) {
+            return dispatch(failOverpassRequest('no drawn shape'));
+        }
 
         const requestData = createOverpassAPIRequestFormData(
             drawnShape,

--- a/src/app/js/src/actions.data.js
+++ b/src/app/js/src/actions.data.js
@@ -1,0 +1,35 @@
+export const START_OVERPASS_REQUEST = 'START_OVERPASS_REQUEST';
+export const FAIL_OVERPASS_REQUEST = 'FAIL_OVERPASS_REQUEST';
+export const COMPLETE_OVERPASS_REQUEST = 'COMPLETE_OVERPASS_REQUEST';
+
+function startOverpassRequest() {
+    return {
+        type: START_OVERPASS_REQUEST,
+    };
+}
+
+function failOverpassRequest(e) {
+    window.console.warn(e);
+
+    return {
+        type: FAIL_OVERPASS_REQUEST,
+    };
+}
+
+function completeOverpassRequest(payload) {
+    return {
+        type: COMPLETE_OVERPASS_REQUEST,
+        payload,
+    };
+}
+
+export function makeOverpassAPIRequest() {
+    return (dispatch) => {
+        dispatch(startOverpassRequest());
+
+        return Promise
+            .resolve(1)
+            .then(data => dispatch(completeOverpassRequest(data)))
+            .catch(e => dispatch(failOverpassRequest(e)));
+    };
+}

--- a/src/app/js/src/components/ExtractButton.jsx
+++ b/src/app/js/src/components/ExtractButton.jsx
@@ -1,13 +1,40 @@
 import React from 'react';
+import { bool, func } from 'prop-types';
+import { connect } from 'react-redux';
 
-export default function ExtractButton() {
+import { makeOverpassAPIRequest } from '../actions.data';
+
+function ExtractButton({
+    dispatch,
+    fetching,
+}) {
     return (
         <button
             className="button -extract"
             type="button"
-            onClick={() => window.console.log('Extracting Shapefile from OSM data')}
+            onClick={() => dispatch(makeOverpassAPIRequest())}
+            disabled={fetching}
         >
             EXTRACT
         </button>
     );
 }
+
+ExtractButton.propTypes = {
+    dispatch: func.isRequired,
+    fetching: bool.isRequired,
+};
+
+function mapStateToProps({
+    data: {
+        overpass: {
+            fetching,
+        },
+    },
+}) {
+    return {
+        fetching,
+    };
+}
+
+export default connect(mapStateToProps)(ExtractButton);

--- a/src/app/js/src/components/OSMExtractionMap.jsx
+++ b/src/app/js/src/components/OSMExtractionMap.jsx
@@ -23,6 +23,7 @@ import {
     initialMapZoom,
     drawToolTypeEnum,
     areaOfInterestStyle,
+    overpassDataStyle,
 } from '../constants';
 
 
@@ -102,12 +103,21 @@ class OSMExtractionMap extends Component {
     render() {
         const {
             drawnShape,
+            data,
         } = this.props;
 
         const areaOfInterest = drawnShape ? (
             <GeoJSON
                 data={drawnShape}
                 style={areaOfInterestStyle}
+            />) : null;
+
+        const overpassAPIData = data ? (
+            <GeoJSON
+                data={data}
+                pointToLayer={
+                    (_, latLng) => L.circleMarker(latLng, overpassDataStyle)
+                }
             />) : null;
 
         return (
@@ -125,6 +135,7 @@ class OSMExtractionMap extends Component {
                 />
                 <ZoomControl position="topright" />
                 {areaOfInterest}
+                {overpassAPIData}
             </ReactLeafletMap>
         );
     }
@@ -133,12 +144,14 @@ class OSMExtractionMap extends Component {
 OSMExtractionMap.defaultProps = {
     drawTool: null,
     drawnShape: null,
+    data: null,
 };
 
 OSMExtractionMap.propTypes = {
     dispatch: func.isRequired,
     drawTool: oneOf(Object.values(drawToolTypeEnum)),
     drawnShape: object, // eslint-disable-line react/forbid-prop-types
+    data: object, // eslint-disable-line react/forbid-prop-types
     drawingActive: bool.isRequired,
 };
 
@@ -150,11 +163,17 @@ function mapStateToProps({
             drawnShape,
         },
     },
+    data: {
+        overpass: {
+            data,
+        },
+    },
 }) {
     return {
         drawTool,
         drawingActive,
         drawnShape,
+        data,
     };
 }
 

--- a/src/app/js/src/constants.js
+++ b/src/app/js/src/constants.js
@@ -66,3 +66,5 @@ export const dateRangeOptions = [
         label: 'Past year',
     },
 ];
+
+export const overpassAPIurl = 'https://overpass-api.de/api/interpreter';

--- a/src/app/js/src/constants.js
+++ b/src/app/js/src/constants.js
@@ -68,3 +68,11 @@ export const dateRangeOptions = [
 ];
 
 export const overpassAPIurl = 'https://overpass-api.de/api/interpreter';
+
+export const overpassDataStyle = {
+    color: '#DFB059',
+    fill: true,
+    opacity: 1.0,
+    fillOpacity: 1.0,
+    radius: 5,
+};

--- a/src/app/js/src/reducers.data.js
+++ b/src/app/js/src/reducers.data.js
@@ -1,7 +1,48 @@
-const initialState = {};
+import {
+    START_OVERPASS_REQUEST,
+    FAIL_OVERPASS_REQUEST,
+    COMPLETE_OVERPASS_REQUEST,
+} from './actions.data';
 
-export default function dataReducer(state = initialState, { type }) {
+const initialState = {
+    overpass: {
+        data: null,
+        fetching: false,
+        error: false,
+    },
+};
+
+export default function dataReducer(state = initialState, { type, payload }) {
     switch (type) {
+        case START_OVERPASS_REQUEST:
+            return {
+                ...state,
+                overpass: {
+                    ...state.overpass,
+                    data: null,
+                    fetching: true,
+                    error: false,
+                },
+            };
+        case FAIL_OVERPASS_REQUEST:
+            return {
+                ...state,
+                overpass: {
+                    ...state.overpass,
+                    fetching: false,
+                    error: true,
+                },
+            };
+        case COMPLETE_OVERPASS_REQUEST:
+            return {
+                ...state,
+                overpass: {
+                    ...state.overpass,
+                    fetching: false,
+                    error: false,
+                    data: payload,
+                },
+            };
         default:
             return state;
     }

--- a/src/app/js/src/utils.js
+++ b/src/app/js/src/utils.js
@@ -1,0 +1,6 @@
+export const formData =
+    'data=node%0A++%5Bamenity%3Ddrinking_water%5D%0A++(41.88719899247721%2C12.487506866455078%2C41.89278978584501%2C12.496519088745117)%3B%0Aout%3B';
+
+export function createOverpassAPIRequestFormData() {
+    return formData;
+}

--- a/src/app/js/src/utils.js
+++ b/src/app/js/src/utils.js
@@ -1,5 +1,5 @@
 export const formData =
-    'data=node%0A++%5Bamenity%3Ddrinking_water%5D%0A++(41.88719899247721%2C12.487506866455078%2C41.89278978584501%2C12.496519088745117)%3B%0Aout%3B';
+    'data=%5Bout%3Ajson%5D%3B%0Anode%0A++%5Bamenity%3Ddrinking_water%5D%0A++(41.88478681339328%2C12.487871646881104%2C41.89520166275077%2C12.496154308319092)%3B%0Aout%3B';
 
 export function createOverpassAPIRequestFormData() {
     return formData;

--- a/src/app/js/src/utils.js
+++ b/src/app/js/src/utils.js
@@ -1,6 +1,31 @@
-export const formData =
-    'data=%5Bout%3Ajson%5D%3B%0Anode%0A++%5Bamenity%3Ddrinking_water%5D%0A++(41.88478681339328%2C12.487871646881104%2C41.89520166275077%2C12.496154308319092)%3B%0Aout%3B';
+function convertGeoJSONGeometryToOverPassGeometry({
+    geometry: {
+        coordinates: [
+            feature,
+        ],
+    },
+}) {
+    const lineString = feature
+        .reduce((acc, [x, y]) => acc.concat(' ', y, ' ', x), '')
+        .substr(1);
 
-export function createOverpassAPIRequestFormData() {
-    return formData;
+    return `(poly: "${lineString}")`;
+}
+
+function createFormDataWithGeometry(shape) {
+    const bbox = convertGeoJSONGeometryToOverPassGeometry(shape);
+
+    return `
+[out:json];
+(
+    node["building"]${bbox};
+    way["building"]${bbox};
+    relation["building"]${bbox};
+);
+out;
+`;
+}
+
+export default function createOverpassAPIRequestFormData(drawnShape) {
+    return createFormDataWithGeometry(drawnShape);
 }

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -23,6 +23,7 @@
     "axios": "~0.18.0",
     "leaflet": "~1.3.1",
     "leaflet-draw": "~0.4.14",
+    "osmtogeojson": "2.2.12",
     "prop-types": "~15.6.1",
     "react": "~16.3.1",
     "react-dom": "~16.3.1",

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -82,6 +82,13 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
+JSONStream@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.0.tgz#efc462d5a5bc94ec007f4b22571acd7f6f2ae013"
+  dependencies:
+    jsonparse "0.0.5"
+    through "~2.2.7"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1178,6 +1185,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base64-js@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.2.tgz#024f0f72afa25b75f9c0ee73cd4f55ec1bed9784"
+
 base64-js@^1.0.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
@@ -1290,6 +1301,13 @@ bootstrap-loader@~2.2.0:
     resolve "^1.1.7"
     semver "^5.3.0"
     strip-json-comments "^2.0.1"
+
+bops@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/bops/-/bops-0.0.6.tgz#082d1d55fa01e60dbdc2ebc2dba37f659554cf3a"
+  dependencies:
+    base64-js "0.0.2"
+    to-utf8 "0.0.1"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1856,6 +1874,18 @@ concat-stream@^1.5.0, concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concat-stream@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.0.1.tgz#018b18bc1c7d073a2dc82aa48442341a2c4dd79f"
+  dependencies:
+    bops "0.0.6"
+
+concat-stream@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.2.1.tgz#f35100b6c46378bfba8b6b80f9f0d0ccdf13dc60"
+  dependencies:
+    bops "0.0.6"
+
 connect-history-api-fallback@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
@@ -2375,9 +2405,21 @@ domhandler@2.1:
   dependencies:
     domelementtype "1"
 
+domhandler@2.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.2.1.tgz#59df9dcd227e808b365ae73e1f6684ac3d946fc2"
+  dependencies:
+    domelementtype "1"
+
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.3:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.3.0.tgz#9ad4d59b5af6ca684c62fe6d768ef170e70df192"
   dependencies:
     domelementtype "1"
 
@@ -3227,6 +3269,27 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
+geojson-area@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/geojson-area/-/geojson-area-0.1.0.tgz#d48d807082cfadf4a78df1349be50f38bf1894ae"
+  dependencies:
+    wgs84 "0.0.0"
+
+geojson-numeric@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/geojson-numeric/-/geojson-numeric-0.2.0.tgz#ab9aae2ea9727a4837079acff2aa83c872d72d4a"
+  dependencies:
+    concat-stream "~1.0.1"
+    optimist "~0.3.5"
+
+geojson-rewind@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/geojson-rewind/-/geojson-rewind-0.1.0.tgz#57022a054b196660d755354fe5d26684d90cd019"
+  dependencies:
+    concat-stream "~1.2.1"
+    geojson-area "0.1.0"
+    minimist "0.0.5"
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
@@ -3662,6 +3725,15 @@ html-webpack-plugin@~3.2.0:
     tapable "^1.0.0"
     toposort "^1.0.0"
     util.promisify "1.0.0"
+
+htmlparser2@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.5.1.tgz#6f42f7657dd19c13f7d65de9118417394a0be6d0"
+  dependencies:
+    domelementtype "1"
+    domhandler "2.2"
+    domutils "1.3"
+    readable-stream "1.1"
 
 htmlparser2@~3.3.0:
   version "3.3.0"
@@ -4365,6 +4437,10 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
+jsonparse@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-0.0.5.tgz#330542ad3f0a654665b778f3eb2d9a9fa507ac64"
+
 jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
@@ -4906,6 +4982,10 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -5311,6 +5391,12 @@ opn@^5.1.0:
   dependencies:
     is-wsl "^1.1.0"
 
+optimist@~0.3.5:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
+  dependencies:
+    wordwrap "~0.0.2"
+
 optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
@@ -5369,6 +5455,23 @@ osenv@0, osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+osm-polygon-features@^0.9.1:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/osm-polygon-features/-/osm-polygon-features-0.9.2.tgz#20ae41130c486e49a3b2a3c2b58a1419c4986778"
+
+osmtogeojson@2.2.12:
+  version "2.2.12"
+  resolved "https://registry.yarnpkg.com/osmtogeojson/-/osmtogeojson-2.2.12.tgz#f084f7d7d5f038a4383b31c036347a134b0819d3"
+  dependencies:
+    JSONStream "0.8.0"
+    concat-stream "~1.0.1"
+    geojson-numeric "0.2.0"
+    geojson-rewind "0.1.0"
+    htmlparser2 "3.5.1"
+    optimist "~0.3.5"
+    osm-polygon-features "^0.9.1"
+    xmldom "~0.1.16"
 
 output-file-sync@^1.1.2:
   version "1.1.2"
@@ -6282,6 +6385,15 @@ read-pkg@^3.0.0:
 readable-stream@1.0:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@1.1:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -7385,6 +7497,10 @@ through@^2.3.6, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
+through@~2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.2.7.tgz#6e8e21200191d4eb6a99f6f010df46aa1c6eb2bd"
+
 thunky@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.2.tgz#a862e018e3fb1ea2ec3fce5d55605cf57f247371"
@@ -7438,6 +7554,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+to-utf8@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/to-utf8/-/to-utf8-0.0.1.tgz#d17aea72ff2fba39b9e43601be7b3ff72e089852"
 
 toposort@^1.0.0:
   version "1.0.6"
@@ -7938,6 +8058,10 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
+wgs84@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/wgs84/-/wgs84-0.0.0.tgz#34fdc555917b6e57cf2a282ed043710c049cdc76"
+
 whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
@@ -7965,6 +8089,10 @@ wide-align@^1.1.0:
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
+
+wordwrap@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 wordwrap@~1.0.0:
   version "1.0.0"
@@ -8000,6 +8128,10 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
+
+xmldom@~0.1.16:
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 
 xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## Overview

This PR creates a stock overpass query using the drawn shape sent by the user. 

The workflow for this is currently not the most apparent, but we can fix that as we go.

Connects #6 

### Demo

![buildingdata](https://user-images.githubusercontent.com/4165523/42843976-aab46cc2-89df-11e8-906d-e3f9329777fe.gif)

## Notes

We're going to have to make this Overpass API request way more configurable but it's better to push off handling that until we have the configuration for the actual set of features.

## Testing Instructions

- get this branch, then `update` and `server`
- visit localhost:4567, then draw a box in Guyana and click "Extract" and verify that it retrieves building data. Repeat for the shape/polygon. Note that the data seems to be sparse and is clustered around Georgetown for buildings.
- try it out in IE11 also
