### PR TITLE
Create geocoder

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,4 +20,4 @@
   X-Frame-Options = "DENY"
   X-XSS-Protection = "1; mode=block"
   X-Content-Type-Options = "nosniff"
-  Referrer-Policy = "no-referrer"
+  Referrer-Policy = "origin-when-cross-origin"

--- a/src/js/src/actions.geocoder.js
+++ b/src/js/src/actions.geocoder.js
@@ -1,3 +1,5 @@
+import L from 'leaflet';
+
 import { suggest, geocode, filterSuggestions } from './utils';
 
 import { guyanaBBox } from './constants';
@@ -14,6 +16,11 @@ export const CLEAR_GEOCODER_SEARCH_INPUT = 'CLEAR_GEOCODER_SEARCH_INPUT';
 export const START_SELECT_GEOCODER_SUGGESTION = 'START_SELECT_GEOCODER_SUGGESTION';
 export const FAIL_SELECT_GEOCODER_SUGGESTION = 'FAIL_SELECT_GEOCODER_SUGGESTION';
 export const COMPLETE_SELECT_GEOCODER_SELECTION = 'COMPLETE_SELECT_GEOCODER_SUGGESTION';
+
+export const UPDATE_LATITUDE_COORDINATE = 'UPDATE_LATITUDE_COORDINATE';
+export const UPDATE_LONGITUDE_COORDINATE = 'UPDATE_LONGITUDE_COORDINATE';
+export const COMPLETE_SELECT_COORDINATES_FROM_GEOCODER = 'COMPLETE_SELECT_COORDINATES_FROM_GEOCODER';
+export const FAIL_SELECT_COORDINATES_FROM_GEOCODER = 'FAIL_SELECT_COORDINATES_FROM_GEOCODER';
 
 export function selectGeocoderSearchInput() {
     return {
@@ -120,5 +127,55 @@ export function selectGeocoderSuggestion(magicKey) {
 
                 return dispatch(completeSelectGeocoderSuggestion(results));
             });
+    };
+}
+
+export function updateLatitudeCoordinate(payload) {
+    return {
+        type: UPDATE_LATITUDE_COORDINATE,
+        payload,
+    };
+}
+
+export function updateLongitudeCoordinate(payload) {
+    return {
+        type: UPDATE_LONGITUDE_COORDINATE,
+        payload,
+    };
+}
+
+function failSelectCoordinatesFromGeocoder(e) {
+    window.console.warn(e);
+
+    return {
+        type: FAIL_SELECT_COORDINATES_FROM_GEOCODER,
+    };
+}
+
+function completeSelectCoordinatesFromGeocoder(payload) {
+    return {
+        type: COMPLETE_SELECT_COORDINATES_FROM_GEOCODER,
+        payload,
+    };
+}
+
+export function selectCoordinatesFromGeocoder() {
+    return (dispatch, getState) => {
+        const {
+            geocoder: {
+                search: {
+                    coordinates: {
+                        lat,
+                        lng,
+                    },
+                },
+            },
+        } = getState();
+
+        return Promise
+            .resolve()
+            .then(() => L.latLng(lat, lng))
+            .then(latLng => dispatch(completeSelectCoordinatesFromGeocoder(latLng)))
+            .catch(e => dispatch(failSelectCoordinatesFromGeocoder(e)));
     };
 }

--- a/src/js/src/actions.geocoder.js
+++ b/src/js/src/actions.geocoder.js
@@ -1,0 +1,124 @@
+import { suggest, geocode, filterSuggestions } from './utils';
+
+import { guyanaBBox } from './constants';
+
+export const START_GEOCODER_AUTOCOMPLETE = 'START_GEOCODER_AUTOCOMPLETE';
+export const FAIL_GEOCODER_AUTOCOMPLETE = 'FAIL_GEOCODER_AUTOCOMPLETE';
+export const COMPLETE_GEOCODER_AUTOCOMPLETE = 'COMPLETE_GEOCODER_AUTOCOMPLETE';
+
+export const SELECT_GEOCODER_SEARCH_INPUT = 'SELECT_GEOCODER_SEARCH_INPUT';
+export const SELECT_GEOCODER_COORDINATES_INPUT = 'SELECT_GEOCODER_COORDINATES_INPUT';
+export const UPDATE_GEOCODER_SEARCH_INPUT = 'UPDATE_GEOCODER_SEARCH_INPUT';
+export const CLEAR_GEOCODER_SEARCH_INPUT = 'CLEAR_GEOCODER_SEARCH_INPUT';
+
+export const START_SELECT_GEOCODER_SUGGESTION = 'START_SELECT_GEOCODER_SUGGESTION';
+export const FAIL_SELECT_GEOCODER_SUGGESTION = 'FAIL_SELECT_GEOCODER_SUGGESTION';
+export const COMPLETE_SELECT_GEOCODER_SELECTION = 'COMPLETE_SELECT_GEOCODER_SUGGESTION';
+
+export function selectGeocoderSearchInput() {
+    return {
+        type: SELECT_GEOCODER_SEARCH_INPUT,
+    };
+}
+
+export function selectGeocoderCoordinatesInput() {
+    return {
+        type: SELECT_GEOCODER_COORDINATES_INPUT,
+    };
+}
+
+function startGeocoderAutocomplete() {
+    return {
+        type: START_GEOCODER_AUTOCOMPLETE,
+    };
+}
+
+function completeGeocoderAutocomplete(payload) {
+    return {
+        type: COMPLETE_GEOCODER_AUTOCOMPLETE,
+        payload,
+    };
+}
+
+function failGeocoderAutocomplete(e) {
+    window.console.warn(e);
+
+    return {
+        type: FAIL_GEOCODER_AUTOCOMPLETE,
+    };
+}
+
+export function updateGeocoderSearchInput(payload) {
+    return (dispatch) => {
+        dispatch(startGeocoderAutocomplete());
+
+        dispatch({
+            type: UPDATE_GEOCODER_SEARCH_INPUT,
+            payload,
+        });
+
+        return payload ?
+            suggest
+                .text(payload)
+                .within(guyanaBBox)
+                .run((error, { suggestions }) => {
+                    if (error) {
+                        return dispatch(failGeocoderAutocomplete(error));
+                    }
+
+                    const guyanaSuggestions = filterSuggestions(suggestions);
+
+                    return dispatch(completeGeocoderAutocomplete(guyanaSuggestions));
+                }) :
+            null;
+    };
+}
+
+export function clearGeocoderSearchInput() {
+    return {
+        type: CLEAR_GEOCODER_SEARCH_INPUT,
+    };
+}
+
+function startSelectGeocoderSuggestion() {
+    return {
+        type: START_SELECT_GEOCODER_SUGGESTION,
+    };
+}
+
+function failSelectGeocoderSuggestion(e) {
+    window.console.warn(e);
+
+    return {
+        type: FAIL_SELECT_GEOCODER_SUGGESTION,
+    };
+}
+
+function completeSelectGeocoderSuggestion([payload]) {
+    return (dispatch) => {
+        if (!payload) {
+            return dispatch(failSelectGeocoderSuggestion('No results'));
+        }
+
+        return dispatch({
+            type: COMPLETE_SELECT_GEOCODER_SELECTION,
+            payload,
+        });
+    };
+}
+
+export function selectGeocoderSuggestion(magicKey) {
+    return (dispatch) => {
+        dispatch(startSelectGeocoderSuggestion());
+
+        return geocode
+            .key(magicKey)
+            .run((error, { results }) => {
+                if (error) {
+                    return dispatch(failSelectGeocoderSuggestion(error));
+                }
+
+                return dispatch(completeSelectGeocoderSuggestion(results));
+            });
+    };
+}

--- a/src/js/src/components/OSMGeocoderControl.jsx
+++ b/src/js/src/components/OSMGeocoderControl.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import Control from 'react-leaflet-control';
+import { func, object, oneOf, string } from 'prop-types';
+
+import {
+    selectGeocoderSearchInput,
+    selectGeocoderCoordinatesInput,
+    updateGeocoderSearchInput,
+    clearGeocoderSearchInput,
+    selectGeocoderSuggestion,
+} from '../actions.geocoder';
+
+import {
+    controlPositionsEnum,
+    geocoderInputTypeEnum,
+    geocoderSuggestionsPropType,
+} from '../constants';
+
+export default function OSMGeocoderControl({
+    position,
+    dispatch,
+    activeInput,
+    searchValue,
+    suggestions,
+    selection,
+}) {
+    const suggestionsList = (() => {
+        if (!suggestions || selection) {
+            return null;
+        }
+
+        return (
+            <div className="suggestions">
+                {
+                    suggestions
+                        .map(({ text, magicKey }) => (
+                            <button
+                                key={magicKey}
+                                className="button"
+                                onClick={() => dispatch(selectGeocoderSuggestion(magicKey))}
+                            >
+                                {text}
+                            </button>
+                        ))
+                }
+            </div>
+        );
+    })();
+
+    return (
+        <Control position={position}>
+            <div className="geocoder">
+                <div className="header">
+                    <button
+                        className={
+                            activeInput === geocoderInputTypeEnum.search ?
+                                'tab -on' :
+                                'tab'
+                        }
+                        onClick={() => dispatch(selectGeocoderSearchInput())}
+                    >
+                        Search
+                    </button>
+                    <button
+                        className={
+                            activeInput === geocoderInputTypeEnum.coordinates ?
+                                'tab -on' :
+                                'tab'
+                        }
+                        onClick={() => dispatch(selectGeocoderCoordinatesInput())}
+                    >
+                        Coordinates
+                    </button>
+                </div>
+                <div className="geocoder-input">
+                    <button
+                        className="button"
+                        onClick={() => window.console.log('click')}
+                    >
+                        <i className="fas fa-search icon" />
+                    </button>
+                    <input
+                        type="text"
+                        className="input"
+                        placeholder={activeInput}
+                        value={selection ? selection.text : searchValue}
+                        onChange={
+                            ({ target: { value } }) => dispatch(updateGeocoderSearchInput(value))
+                        }
+                    />
+                    <button
+                        className="button"
+                        onClick={() => dispatch(clearGeocoderSearchInput())}
+                    >
+                        <i className="fas fa-times icon" />
+                    </button>
+                </div>
+                {suggestionsList}
+            </div>
+        </Control>
+    );
+}
+
+OSMGeocoderControl.defaultProps = {
+    suggestions: null,
+    selection: null,
+};
+
+OSMGeocoderControl.propTypes = {
+    position: oneOf(Object.values(controlPositionsEnum)).isRequired,
+    activeInput: oneOf(Object.values(geocoderInputTypeEnum)).isRequired,
+    searchValue: string.isRequired,
+    suggestions: geocoderSuggestionsPropType,
+    selection: object, // eslint-disable-line react/forbid-prop-types
+    dispatch: func.isRequired,
+};

--- a/src/js/src/components/OSMGeocoderControl.jsx
+++ b/src/js/src/components/OSMGeocoderControl.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Control from 'react-leaflet-control';
-import { func, object, oneOf, string } from 'prop-types';
+import { func, number, object, oneOf, oneOfType, string } from 'prop-types';
 
 import {
     selectGeocoderSearchInput,
@@ -8,6 +8,9 @@ import {
     updateGeocoderSearchInput,
     clearGeocoderSearchInput,
     selectGeocoderSuggestion,
+    updateLatitudeCoordinate,
+    updateLongitudeCoordinate,
+    selectCoordinatesFromGeocoder,
 } from '../actions.geocoder';
 
 import {
@@ -16,6 +19,8 @@ import {
     geocoderSuggestionsPropType,
 } from '../constants';
 
+const ENTER = 'Enter';
+
 export default function OSMGeocoderControl({
     position,
     dispatch,
@@ -23,6 +28,8 @@ export default function OSMGeocoderControl({
     searchValue,
     suggestions,
     selection,
+    lat,
+    lng,
 }) {
     const suggestionsList = (() => {
         if (!suggestions || selection) {
@@ -46,6 +53,71 @@ export default function OSMGeocoderControl({
             </div>
         );
     })();
+
+    const maybeSubmitCoordinates = (e) => {
+        if (e.key === ENTER) {
+            e.preventDefault();
+
+            dispatch(selectCoordinatesFromGeocoder());
+        }
+    };
+
+    const inputs = activeInput === geocoderInputTypeEnum.search ? (
+        <div className="geocoder-input">
+            <button
+                className="button"
+                onClick={() => window.console.log('click')}
+            >
+                <i className="fas fa-search icon" />
+            </button>
+            <input
+                type="text"
+                className="input"
+                placeholder={activeInput}
+                value={selection ? selection.text : searchValue}
+                onChange={
+                    ({ target: { value } }) => dispatch(updateGeocoderSearchInput(value))
+                }
+            />
+            <button
+                className="button"
+                onClick={() => dispatch(clearGeocoderSearchInput())}
+            >
+                <i className="fas fa-times icon" />
+            </button>
+        </div>
+    ) : (
+        <div className="geocoder-input">
+            <div className="coordinates">
+                <input
+                    type="text"
+                    className="coordinate"
+                    placeholder="Lat"
+                    value={lat}
+                    onChange={
+                        ({ target: { value } }) => dispatch(updateLatitudeCoordinate(value))
+                    }
+                    onKeyDown={maybeSubmitCoordinates}
+                />
+                <input
+                    type="text"
+                    className="coordinate"
+                    placeholder="Long"
+                    value={lng}
+                    onChange={
+                        ({ target: { value } }) => dispatch(updateLongitudeCoordinate(value))
+                    }
+                    onKeyDown={maybeSubmitCoordinates}
+                />
+            </div>
+            <button
+                className="button"
+                onClick={() => dispatch(selectCoordinatesFromGeocoder())}
+            >
+                <i className="fas fa-search icon" />
+            </button>
+        </div>
+    );
 
     return (
         <Control position={position}>
@@ -72,29 +144,7 @@ export default function OSMGeocoderControl({
                         Coordinates
                     </button>
                 </div>
-                <div className="geocoder-input">
-                    <button
-                        className="button"
-                        onClick={() => window.console.log('click')}
-                    >
-                        <i className="fas fa-search icon" />
-                    </button>
-                    <input
-                        type="text"
-                        className="input"
-                        placeholder={activeInput}
-                        value={selection ? selection.text : searchValue}
-                        onChange={
-                            ({ target: { value } }) => dispatch(updateGeocoderSearchInput(value))
-                        }
-                    />
-                    <button
-                        className="button"
-                        onClick={() => dispatch(clearGeocoderSearchInput())}
-                    >
-                        <i className="fas fa-times icon" />
-                    </button>
-                </div>
+                {inputs}
                 {suggestionsList}
             </div>
         </Control>
@@ -113,4 +163,6 @@ OSMGeocoderControl.propTypes = {
     suggestions: geocoderSuggestionsPropType,
     selection: object, // eslint-disable-line react/forbid-prop-types
     dispatch: func.isRequired,
+    lat: oneOfType([number, string]).isRequired,
+    lng: oneOfType([number, string]).isRequired,
 };

--- a/src/js/src/constants.js
+++ b/src/js/src/constants.js
@@ -1,6 +1,9 @@
+import L from 'leaflet';
+import { arrayOf, bool, shape, string } from 'prop-types';
+
 export const basemapTilesUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 export const basemapAttribution =
-    '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>';
+    'Powered by <a href="https://esri.com">Esri</a> | &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>';
 export const basemapMaxZoom = 19;
 
 export const initialMapCenter = [
@@ -76,3 +79,28 @@ export const overpassDataStyle = {
     fillOpacity: 1.0,
     radius: 5,
 };
+
+export const controlPositionsEnum = {
+    topright: 'topright',
+    topleft: 'topleft',
+    bottomright: 'bottomright',
+    bottomleft: 'bottomleft',
+};
+
+export const geocoderInputTypeEnum = {
+    search: 'search',
+    coordinates: 'coordinates',
+};
+
+export const geocoderSuggestionsPropType = arrayOf(shape({
+    text: string,
+    magicKey: string,
+    isCollection: bool,
+}));
+
+export const geocoderUrl = 'https://utility.arcgis.com/usrsvcs/appservices/6Ag9gwdkF9pH4nRm/rest/services/World/GeocodeServer/';
+
+export const guyanaBBox = L.latLngBounds(
+    L.latLng(1.26808828369, -56.5393857489),
+    L.latLng(8.36703481692, -61.4103029039),
+);

--- a/src/js/src/reducers.geocoder.js
+++ b/src/js/src/reducers.geocoder.js
@@ -9,6 +9,9 @@ import {
     START_SELECT_GEOCODER_SUGGESTION,
     FAIL_SELECT_GEOCODER_SUGGESTION,
     COMPLETE_SELECT_GEOCODER_SELECTION,
+    UPDATE_LATITUDE_COORDINATE,
+    UPDATE_LONGITUDE_COORDINATE,
+    COMPLETE_SELECT_COORDINATES_FROM_GEOCODER,
 } from './actions.geocoder';
 
 import { geocoderInputTypeEnum } from './constants';
@@ -16,17 +19,66 @@ import { geocoderInputTypeEnum } from './constants';
 const initialState = {
     results: {
         suggestions: null,
+        coordinates: null,
         selection: null,
         error: false,
     },
     search: {
         activeInput: geocoderInputTypeEnum.search,
         searchValue: '',
+        coordinates: {
+            lat: '',
+            lng: '',
+        },
     },
 };
 
 export default function geocoderReducer(state = initialState, { type, payload }) {
     switch (type) {
+        case UPDATE_LATITUDE_COORDINATE:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    coordinates: null,
+                },
+                search: {
+                    ...state.search,
+                    searchValue: initialState.search.searchValue,
+                    coordinates: {
+                        ...state.search.coordinates,
+                        lat: payload,
+                    },
+                },
+            };
+        case UPDATE_LONGITUDE_COORDINATE:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    coordinates: null,
+                },
+                search: {
+                    ...state.search,
+                    searchValue: initialState.search.searchValue,
+                    coordinates: {
+                        ...state.search.coordinates,
+                        lng: payload,
+                    },
+                },
+            };
+        case COMPLETE_SELECT_COORDINATES_FROM_GEOCODER:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    coordinates: payload,
+                },
+                search: {
+                    ...state.search,
+                    coordinates: payload,
+                },
+            };
         case START_SELECT_GEOCODER_SUGGESTION:
             return state;
         case FAIL_SELECT_GEOCODER_SUGGESTION:
@@ -73,6 +125,7 @@ export default function geocoderReducer(state = initialState, { type, payload })
                 search: {
                     ...state.search,
                     searchValue: payload,
+                    coordinates: initialState.search.coordinates,
                 },
             };
         case CLEAR_GEOCODER_SEARCH_INPUT:
@@ -86,6 +139,7 @@ export default function geocoderReducer(state = initialState, { type, payload })
                 search: {
                     ...state.search,
                     searchValue: initialState.search.searchValue,
+                    coordinates: initialState.search.coordinates,
                 },
             };
         case START_GEOCODER_AUTOCOMPLETE:

--- a/src/js/src/reducers.geocoder.js
+++ b/src/js/src/reducers.geocoder.js
@@ -1,0 +1,119 @@
+import {
+    SELECT_GEOCODER_SEARCH_INPUT,
+    SELECT_GEOCODER_COORDINATES_INPUT,
+    UPDATE_GEOCODER_SEARCH_INPUT,
+    CLEAR_GEOCODER_SEARCH_INPUT,
+    START_GEOCODER_AUTOCOMPLETE,
+    COMPLETE_GEOCODER_AUTOCOMPLETE,
+    FAIL_GEOCODER_AUTOCOMPLETE,
+    START_SELECT_GEOCODER_SUGGESTION,
+    FAIL_SELECT_GEOCODER_SUGGESTION,
+    COMPLETE_SELECT_GEOCODER_SELECTION,
+} from './actions.geocoder';
+
+import { geocoderInputTypeEnum } from './constants';
+
+const initialState = {
+    results: {
+        suggestions: null,
+        selection: null,
+        error: false,
+    },
+    search: {
+        activeInput: geocoderInputTypeEnum.search,
+        searchValue: '',
+    },
+};
+
+export default function geocoderReducer(state = initialState, { type, payload }) {
+    switch (type) {
+        case START_SELECT_GEOCODER_SUGGESTION:
+            return state;
+        case FAIL_SELECT_GEOCODER_SUGGESTION:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    error: true,
+                },
+            };
+        case COMPLETE_SELECT_GEOCODER_SELECTION:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    suggestions: initialState.results.suggestions,
+                    selection: payload,
+                    error: false,
+                },
+            };
+        case SELECT_GEOCODER_SEARCH_INPUT:
+            return {
+                ...state,
+                search: {
+                    ...state.search,
+                    activeInput: geocoderInputTypeEnum.search,
+                },
+            };
+        case SELECT_GEOCODER_COORDINATES_INPUT:
+            return {
+                ...state,
+                search: {
+                    ...state.search,
+                    activeInput: geocoderInputTypeEnum.coordinates,
+                },
+            };
+        case UPDATE_GEOCODER_SEARCH_INPUT:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    selection: null,
+                },
+                search: {
+                    ...state.search,
+                    searchValue: payload,
+                },
+            };
+        case CLEAR_GEOCODER_SEARCH_INPUT:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    selection: null,
+                    suggestions: null,
+                },
+                search: {
+                    ...state.search,
+                    searchValue: initialState.search.searchValue,
+                },
+            };
+        case START_GEOCODER_AUTOCOMPLETE:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    suggestions: null,
+                    error: null,
+                },
+            };
+        case COMPLETE_GEOCODER_AUTOCOMPLETE:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    suggestions: payload,
+                },
+            };
+        case FAIL_GEOCODER_AUTOCOMPLETE:
+            return {
+                ...state,
+                results: {
+                    ...state.results,
+                    error: true,
+                },
+            };
+        default:
+            return state;
+    }
+}

--- a/src/js/src/reducers.js
+++ b/src/js/src/reducers.js
@@ -2,8 +2,10 @@ import { combineReducers } from 'redux';
 
 import uiReducer from './reducers.ui';
 import dataReducer from './reducers.data';
+import geocoderReducer from './reducers.geocoder';
 
 export default combineReducers({
     ui: uiReducer,
     data: dataReducer,
+    geocoder: geocoderReducer,
 });

--- a/src/js/src/utils.js
+++ b/src/js/src/utils.js
@@ -1,4 +1,7 @@
 import shpwrite from 'shp-write';
+import * as esriGeocoder from 'esri-leaflet-geocoder';
+
+import { geocoderUrl } from './constants';
 
 function convertGeoJSONGeometryToOverPassGeometry({
     geometry: {
@@ -63,4 +66,36 @@ export function downloadShapefile(geojson, dateRange, features = 'buildings') {
     });
 
     return geojson;
+}
+
+export const geocodingService = esriGeocoder.geocodeService({
+    url: geocoderUrl,
+    supportsSuggest: true,
+    categories: [
+        'Address',
+        'Postal',
+        'Populated Place',
+    ],
+});
+
+export const suggest = geocodingService.suggest();
+export const geocode = geocodingService.geocode();
+
+/**
+ * Filter non-Guyana locations out of the list of geocoder suggestions
+ * @param {array} suggestions the geocoder's list of suggestions
+ * @returns {array} A filtered list of suggestions
+ */
+export function filterSuggestions(suggestions = []) {
+    return suggestions
+        .reduce((acc, next) => {
+            if (next.text.indexOf(', BRA') > -1 ||
+                next.text.indexOf(', VEN') > -1 ||
+                next.text.indexOf(', SUR') > -1 ||
+                next.text.indexOf(', TTO') > -1) {
+                return acc;
+            }
+
+            return acc.concat(next);
+        }, []);
 }

--- a/src/package.json
+++ b/src/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/azavea/idb-osm-extraction-tool",
   "dependencies": {
     "axios": "~0.18.0",
+    "esri-leaflet-geocoder": "~2.2.13",
     "leaflet": "~1.3.1",
     "leaflet-draw": "~0.4.14",
     "osmtogeojson": "2.2.12",

--- a/src/package.json
+++ b/src/package.json
@@ -30,6 +30,7 @@
     "react-dom": "~16.3.1",
     "react-hot-loader": "~4.0.1",
     "react-leaflet": "~1.9.1",
+    "react-leaflet-control": "~1.4.1",
     "react-loadable": "~5.4.0",
     "react-redux": "~5.0.7",
     "react-router": "~4.2.0",

--- a/src/sass/geocoder.scss
+++ b/src/sass/geocoder.scss
@@ -46,6 +46,16 @@
             width: 14rem;
             font-size: 1.3rem;
         }
+
+        > .coordinates {
+            display: flex;
+
+            > .coordinate {
+                height: 1.6rem;
+                width: 45%;
+                font-size: 1.4rem;
+            }
+        }
     }
 
     > .suggestions {

--- a/src/sass/geocoder.scss
+++ b/src/sass/geocoder.scss
@@ -1,0 +1,64 @@
+.geocoder {
+    width: 20rem;
+    background-color: $white;
+    display: flex;
+    flex-direction: column;
+
+    > .header {
+        display: flex;
+        background-color: $turquoise;
+        height: 2rem;
+        justify-content: flex-start;
+
+        > .tab {
+            height: 100%;
+            width: 30%;
+            align-self: center;
+            font-weight: 700;
+            border: none;
+            background-color: $turquoise;
+            color: $white;
+
+            &.-on {
+                background-color: $highlight !important;
+            }
+        }
+    }
+
+    > .geocoder-input {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        margin: 0.5rem;
+        height: 2rem;
+
+        > .button {
+            border: none;
+            background-color: $white;
+
+            > .icon {
+                font-size: 1.2rem;
+            }
+        }
+
+        > .input {
+            height: 1.5rem;
+            width: 14rem;
+            font-size: 1.3rem;
+        }
+    }
+
+    > .suggestions {
+        display: flex;
+        flex-direction: column;
+
+        > .button {
+            background-color: $white;
+            border: none;
+            display: flex;
+            justify-content: left;
+            font-size: 1rem;
+            margin: 0.5rem;
+        }
+    }
+}

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -6,3 +6,4 @@
 @import "loading.scss";
 @import "map.scss";
 @import "sidebar.scss";
+@import "geocoder.scss";

--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -1,5 +1,6 @@
 // Colors
 $turquoise: #0A393C;
+$highlight: #0E494C;
 $yellow: #DFB059;
 $white: #FFFFFF;
 $lightgray: #F0EDEE;

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -6204,7 +6204,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.0, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@~15.6.1:
+prop-types@^15.5.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@~15.6.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -6373,6 +6373,12 @@ react-input-autosize@^2.1.2:
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
   dependencies:
     prop-types "^15.5.8"
+
+react-leaflet-control@~1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-leaflet-control/-/react-leaflet-control-1.4.1.tgz#5da234621682d9c50657b65af042398512bda0fb"
+  dependencies:
+    prop-types "^15.5.7"
 
 react-leaflet@~1.9.1:
   version "1.9.1"

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -78,6 +78,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@esri/arcgis-to-geojson-utils@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@esri/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.3.0.tgz#79ab65bf3e40c039dbdebceff4b3b0ec088b189c"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -2816,6 +2820,21 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
+esri-leaflet-geocoder@~2.2.13:
+  version "2.2.13"
+  resolved "https://registry.yarnpkg.com/esri-leaflet-geocoder/-/esri-leaflet-geocoder-2.2.13.tgz#b56660e6d27e6974adbe687f700892c9282dc45c"
+  dependencies:
+    esri-leaflet "^2.1.4"
+    leaflet "^1.0.0"
+
+esri-leaflet@^2.1.4:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/esri-leaflet/-/esri-leaflet-2.2.1.tgz#798d875ffeca8047d7fb4510f54b7bab2146ed84"
+  dependencies:
+    "@esri/arcgis-to-geojson-utils" "^1.3.0"
+    leaflet-virtual-grid "^1.0.7"
+    tiny-binary-search "^1.0.3"
+
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
@@ -4585,7 +4604,13 @@ leaflet-draw@~0.4.14:
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/leaflet-draw/-/leaflet-draw-0.4.14.tgz#1b5b06d570873a015aa96b80d664dab496c45a4a"
 
-leaflet@~1.3.1:
+leaflet-virtual-grid@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/leaflet-virtual-grid/-/leaflet-virtual-grid-1.0.7.tgz#0dbb0dacd506b6e6d291314da5022d348729f8ad"
+  dependencies:
+    leaflet "^1.0.0"
+
+leaflet@^1.0.0, leaflet@~1.3.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.3.3.tgz#5c8f2fd50e4a41ead93ab850dcd9e058811da9b9"
 
@@ -7630,6 +7655,10 @@ timers-browserify@^2.0.4:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-binary-search@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz#9d52e3d16dd1171eb74486caf704ba08c0c62186"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
## Overview

This PR implements the geocoder control mostly as depicted in the wireframes.

For the geocoder, we use the Esri world geocoder. I've set up an app under the Azavea organization and I added the relevant domains there.

For coordinate search, we just use the builtin Leaflet L.latLng class to attempt the conversion, doing the work in a Promise so that if it fails we can catch it as normal.

I temporarily switched out the basemap for Positron because the OSM tile server was not responding. I'll drop that commit before merging.

Connects #9

### Demo

![geocoder](https://user-images.githubusercontent.com/4165523/43484887-a26365ba-94dd-11e8-9d49-060bc760a0c9.gif)

![coordinates](https://user-images.githubusercontent.com/4165523/43484891-a579ef4e-94dd-11e8-94ba-691c417af94c.gif)


### Notes

I filtered the geocoder suggestions using a Guyana bbox, then filtered more to remove countries which are not Guyana.

## Testing Instructions

The dev environment has changed since the last time a PR went up against this project, so it's probably best to start by destroying your prior VM and rm -rf the repo, then cloning the repo again and running `./scripts/setup`

Once that's done, serve the app on localhost:4567 and visit the page in the browser in both Chrome and IE 11 and verify

- you can use the geocoder to get results and select from the suggestions to zoom to the aoi
- the coordinate search works and handles errors properly

There's a Netlify site deployed linked below which you can also check.