### PR TITLE
Add instructions modal

### DIFF
--- a/src/js/src/actions.ui.js
+++ b/src/js/src/actions.ui.js
@@ -4,6 +4,8 @@ export const CANCEL_DRAWING = 'CANCEL_DRAWING';
 export const COMPLETE_DRAWING = 'COMPLETE_DRAWING';
 export const SELECT_DATE_RANGE = 'SELECT_DATE_RANGE';
 export const SELECT_FEATURES = 'SELECT_FEATURES';
+export const SHOW_MODAL = 'SHOW_MODAL';
+export const HIDE_MODAL = 'HIDE_MODAL';
 
 export function startDrawingBox() {
     return {
@@ -41,5 +43,17 @@ export function selectFeatures(payload) {
     return {
         type: SELECT_FEATURES,
         payload,
+    };
+}
+
+export function showModal() {
+    return {
+        type: SHOW_MODAL,
+    };
+}
+
+export function hideModal() {
+    return {
+        type: HIDE_MODAL,
     };
 }

--- a/src/js/src/components/Header.jsx
+++ b/src/js/src/components/Header.jsx
@@ -1,11 +1,55 @@
 import React from 'react';
+import { bool, func } from 'prop-types';
+import { connect } from 'react-redux';
+import Popup from 'reactjs-popup';
 
-export default function Header() {
+import {
+    showModal,
+    hideModal,
+} from '../actions.ui';
+
+import InfoModal from './InfoModal';
+
+function Header({
+    dispatch,
+    modalVisible,
+}) {
     return (
         <div className="header">
             <h3 className="title">
                 OSM EXTRACTION TOOL
             </h3>
+            <Popup
+                open={modalVisible}
+                modal
+                closeOnDocumentClick
+                onClose={() => dispatch(hideModal())}
+            >
+                <InfoModal />
+            </Popup>
+            <button
+                onClick={() => dispatch(showModal())}
+                className="info button"
+            >
+                <i className="fa fa-info-circle" />
+            </button>
         </div>
     );
 }
+
+Header.propTypes = {
+    dispatch: func.isRequired,
+    modalVisible: bool.isRequired,
+};
+
+function mapStateToProps({
+    ui: {
+        modalVisible,
+    },
+}) {
+    return {
+        modalVisible,
+    };
+}
+
+export default connect(mapStateToProps)(Header);

--- a/src/js/src/components/InfoModal.jsx
+++ b/src/js/src/components/InfoModal.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { func } from 'prop-types';
+import { connect } from 'react-redux';
+
+import { hideModal } from '../actions.ui';
+
+const listItems = [
+    {
+        header: 'Draw site boundaries',
+        description: `Draw the boundaries of the location in which you will be
+            building your development on the map.`,
+    },
+    {
+        header: 'Feature',
+        description: `Select the feature that you need to extract. Features are
+            natural or manmade points, lines, or areas on the map, such as
+            bodies of water or streets.`,
+    },
+    {
+        header: 'Date range',
+        description: `OpenStreetMap data is an open source project updated by
+            volunteers like yourself. If you need data from a specific period
+            of time (particularly if you have just made an update yourself)
+            use the pre-selected options or the date-picker.`,
+        optional: true,
+    },
+    {
+        header: 'Extract',
+        description: `If you have selected site boundaries and map features,
+            the extract button should be enabled. Extract your data by clicking
+            this button, and then check your downloads folder.`,
+    },
+    {
+        header: 'Incorrect data',
+        description: `If you notice that data in your download or visible on
+            the map looks incorrect, you can`,
+        unnumbered: true,
+        link: (
+            <a
+                href="https://www.openstreetmap.org/"
+                className="link"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                go to OSM to fix it!
+                <i className="fas fa-external-link-square-alt" />
+            </a>
+        ),
+    },
+];
+
+function InfoModal({
+    dispatch,
+}) {
+    const instructionsList = listItems.map(({
+        header,
+        description,
+        optional,
+        unnumbered,
+        link,
+    }, index) => (
+        <li
+            key={header}
+            className="item"
+        >
+            <div className="number">
+                {
+                    unnumbered ?
+                        <i className="fas fa-ban" /> :
+                        index + 1
+                }
+            </div>
+            <div className="text">
+                <div className="header">
+                    {header} {
+                        optional ? (
+                            <span className="optional">
+                                (optional)
+                            </span>) : null
+                    }
+                </div>
+                <div className="description">
+                    {description} {link || null}
+                </div>
+            </div>
+        </li>));
+
+    return (
+        <div className="info-modal">
+            <button
+                className="button -close"
+                onClick={() => dispatch(hideModal())}
+            >
+                <i className="fas fa-times" />
+            </button>
+            <div className="header">
+                About the OSM Extraction Tool
+            </div>
+            <div className="description">
+                The OSM Extraction Tool was created by the Inter-American
+                Development Bank in partnership with CH&PA in Guyana.
+            </div>
+            <div className="instructions">
+                <div className="header">
+                    How to use
+                </div>
+                <ul className="list">
+                    {instructionsList}
+                </ul>
+            </div>
+            <button
+                className="button -back"
+                onClick={() => dispatch(hideModal())}
+            >
+                Back to Map
+            </button>
+        </div>
+    );
+}
+
+InfoModal.propTypes = {
+    dispatch: func.isRequired,
+};
+
+export default connect(() => ({}))(InfoModal);

--- a/src/js/src/reducers.ui.js
+++ b/src/js/src/reducers.ui.js
@@ -5,6 +5,8 @@ import {
     COMPLETE_DRAWING,
     SELECT_DATE_RANGE,
     SELECT_FEATURES,
+    SHOW_MODAL,
+    HIDE_MODAL,
 } from './actions.ui';
 
 import { drawToolTypeEnum } from './constants';
@@ -19,10 +21,21 @@ const initialState = {
         dateRange: null,
         features: null,
     },
+    modalVisible: false,
 };
 
 export default function uiReducer(state = initialState, { type, payload }) {
     switch (type) {
+        case SHOW_MODAL:
+            return {
+                ...state,
+                modalVisible: true,
+            };
+        case HIDE_MODAL:
+            return {
+                ...state,
+                modalVisible: false,
+            };
         case START_DRAWING_BOX:
             return {
                 ...state,

--- a/src/package.json
+++ b/src/package.json
@@ -37,6 +37,7 @@
     "react-router": "~4.2.0",
     "react-router-dom": "~4.2.2",
     "react-select": "~1.2.0",
+    "reactjs-popup": "~1.1.0",
     "redux": "~3.7.2",
     "redux-logger": "~3.0.6",
     "redux-thunk": "~2.2.0",

--- a/src/sass/infomodal.scss
+++ b/src/sass/infomodal.scss
@@ -1,0 +1,109 @@
+.popup-content {
+    max-width: 50%;
+    max-height: 65%;
+    overflow-y: scroll;
+
+    > .info-modal {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 2rem;
+
+        > .button {
+            &.-close {
+                border: none;
+                display: flex;
+                align-self: flex-end;
+                font-size: 1.2rem;
+            }
+
+            &.-back {
+                border: none;
+                background-color: $turquoise;
+                height: 4rem;
+                width: 18rem;
+                font-size: 1.2rem;
+                color: $white;
+                text-transform: uppercase;
+            }
+        }
+
+        > .header {
+            font-weight: 700;
+            padding: 1rem;
+        }
+
+        > .description {
+            padding: 1rem;
+            width: 80%;
+        }
+
+        > .instructions {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            width: 85%;
+
+            > .header {
+                font-weight: 700;
+                text-transform: uppercase;
+            }
+
+            > .list {
+                list-style: none;
+                padding: 0.5rem;
+
+                > .item {
+                    display: flex;
+                    flex-direction: row;
+                    align-items: flex-start;
+                    padding: 0.5rem;
+
+                    > .number {
+                        background-color: $lightgray;
+                        padding: 0.5rem;
+                        margin-right: 1rem;
+
+                        > .fa-ban {
+                            color: red;
+                        }
+                    }
+
+                    > .text {
+                        padding: 0.5rem;
+
+                        > .header {
+                            font-weight: 700;
+                            padding-bottom: 0.5rem;
+
+                            > .optional {
+                                font-weight: 400;
+                            }
+                        }
+
+                        > .description {
+                            a:link,
+                            a:visited,
+                            a:hover,
+                            a:active {
+                                color: $black;
+                            }
+
+                            > .link {
+                                display: inline-flex;
+                                text-decoration-color: $yellow;
+
+                                > .fa-external-link-square-alt {
+                                    color: $yellow;
+                                    padding-left: 0.5rem;
+                                    text-decoration: underline;
+                                    text-decoration-color: $yellow;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sass/infomodal.scss
+++ b/src/sass/infomodal.scss
@@ -1,103 +1,109 @@
-.popup-content {
-    max-width: 50%;
-    max-height: 65%;
-    overflow-y: scroll;
+.popup-overlay {
+    z-index: 100;
+    > .popup-content {
+        max-width: 50%;
+        max-height: 65%;
+        overflow-y: scroll;
+        align-self: center;
 
-    > .info-modal {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        padding: 2rem;
-
-        > .button {
-            &.-close {
-                border: none;
-                display: flex;
-                align-self: flex-end;
-                font-size: 1.2rem;
-            }
-
-            &.-back {
-                border: none;
-                background-color: $turquoise;
-                height: 4rem;
-                width: 18rem;
-                font-size: 1.2rem;
-                color: $white;
-                text-transform: uppercase;
-            }
-        }
-
-        > .header {
-            font-weight: 700;
-            padding: 1rem;
-        }
-
-        > .description {
-            padding: 1rem;
-            width: 80%;
-        }
-
-        > .instructions {
+        > .info-modal {
             display: flex;
             flex-direction: column;
             align-items: center;
-            width: 85%;
+            padding: 2rem;
+
+            > .button {
+                &.-close {
+                    border: none;
+                    background-color: transparent;
+                    display: flex;
+                    align-self: flex-end;
+                    font-size: 1.2rem;
+                }
+
+                &.-back {
+                    border: none;
+                    background-color: $turquoise;
+                    height: 4rem;
+                    width: 18rem;
+                    font-size: 1.2rem;
+                    color: $white;
+                    text-transform: uppercase;
+                }
+            }
 
             > .header {
                 font-weight: 700;
-                text-transform: uppercase;
+                padding: 1rem;
             }
 
-            > .list {
-                list-style: none;
-                padding: 0.5rem;
+            > .description {
+                padding: 1rem;
+                width: 80%;
+            }
 
-                > .item {
-                    display: flex;
-                    flex-direction: row;
-                    align-items: flex-start;
+            > .instructions {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                width: 85%;
+
+                > .header {
+                    font-weight: 700;
+                    text-transform: uppercase;
+                }
+
+                > .list {
+                    list-style: none;
                     padding: 0.5rem;
+                    width: 100%;
 
-                    > .number {
-                        background-color: $lightgray;
-                        padding: 0.5rem;
-                        margin-right: 1rem;
-
-                        > .fa-ban {
-                            color: red;
-                        }
-                    }
-
-                    > .text {
+                    > .item {
+                        display: flex;
+                        flex-direction: row;
+                        align-items: flex-start;
                         padding: 0.5rem;
 
-                        > .header {
-                            font-weight: 700;
-                            padding-bottom: 0.5rem;
+                        > .number {
+                            background-color: $lightgray;
+                            padding: 0.5rem;
+                            margin-right: 1rem;
 
-                            > .optional {
-                                font-weight: 400;
+                            > .fa-ban {
+                                color: red;
                             }
                         }
 
-                        > .description {
-                            a:link,
-                            a:visited,
-                            a:hover,
-                            a:active {
-                                color: $black;
+                        > .text {
+                            padding: 0.5rem;
+
+                            > .header {
+                                font-weight: 700;
+                                padding-bottom: 0.5rem;
+
+                                > .optional {
+                                    font-weight: 400;
+                                }
                             }
 
-                            > .link {
-                                display: inline-flex;
-                                text-decoration-color: $yellow;
+                            > .description {
+                                a:link,
+                                a:visited,
+                                a:hover,
+                                a:active {
+                                    color: $black;
+                                }
 
-                                > .fa-external-link-square-alt {
-                                    color: $yellow;
-                                    padding-left: 0.5rem;
-                                    text-decoration: underline;
+                                > .link {
+                                    display: inline-flex;
                                     text-decoration-color: $yellow;
+
+                                    > .fa-external-link-square-alt {
+                                        color: $yellow;
+                                        padding-left: 0.5rem;
+                                        text-decoration: underline;
+                                        text-decoration-color: $yellow;
+                                    }
                                 }
                             }
                         }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -7,3 +7,4 @@
 @import "map.scss";
 @import "sidebar.scss";
 @import "geocoder.scss";
+@import "infomodal.scss";

--- a/src/sass/map.scss
+++ b/src/sass/map.scss
@@ -1,6 +1,7 @@
 #osm-extraction-map {
     height: 100%;
     width: 100%;
+    z-index: 50;
 
     > .leaflet-control-container {
         > .leaflet-right {

--- a/src/sass/sidebar.scss
+++ b/src/sass/sidebar.scss
@@ -11,11 +11,20 @@
         height: 4rem;
         width: 100%;
         display: flex;
-        justify-content: space-around;
+        justify-content: space-evenly;
         align-items: center;
 
         > .title {
             color: $white;
+        }
+
+        > .info {
+            &.button {
+                border: none;
+                background-color: unset;
+                color: $white;
+                font-size: 1.2rem;
+            }
         }
     }
 

--- a/src/sass/sidebar.scss
+++ b/src/sass/sidebar.scss
@@ -11,7 +11,7 @@
         height: 4rem;
         width: 100%;
         display: flex;
-        justify-content: space-evenly;
+        justify-content: space-around;
         align-items: center;
 
         > .title {
@@ -21,7 +21,7 @@
         > .info {
             &.button {
                 border: none;
-                background-color: unset;
+                background-color: transparent;
                 color: $white;
                 font-size: 1.2rem;
             }

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -6482,6 +6482,10 @@ react@~16.3.1:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+reactjs-popup@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/reactjs-popup/-/reactjs-popup-1.1.1.tgz#a0619ba6a309aea379df6e82afc110efea180560"
+
 read-chunk@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-2.1.0.tgz#6a04c0928005ed9d42e1a6ac5600e19cbc7ff655"


### PR DESCRIPTION
## Overview

This PR creates the instructions modal depicted in the wireframes.

I used this library -- https://react-popup.netlify.com/home/ -- for the modal instead of react-modal.

Only https://github.com/azavea/idb-osm-extraction-tool/commit/da56e627c171feab5b0298fe33bab2d884e185f8 is from this PR.

Connects #12

### Demo

![screen shot 2018-08-01 at 1 32 32 pm](https://user-images.githubusercontent.com/4165523/43538217-636efae2-958f-11e8-8fb1-1fbee1af3e9d.png)

## Testing Instructions

- check the staging deployment on screens of various sizes in IE11 and Chrome to see that the modal works and dismisses properly and that you don't see any errors in the console
- read the code from https://github.com/azavea/idb-osm-extraction-tool/commit/da56e627c171feab5b0298fe33bab2d884e185f8 and verify that it's good to go in