### PR TITLE
Circumvent rectangle draw bug for IE 11

### DIFF
--- a/src/js/src/components/OSMExtractionMap.jsx
+++ b/src/js/src/components/OSMExtractionMap.jsx
@@ -31,11 +31,14 @@ import {
 
 import OSMGeocoderControl from './OSMGeocoderControl';
 
+const PRECLICK = 'preclick';
+
 class OSMExtractionMap extends Component {
     constructor(props) {
         super(props);
         this.handleDrawAreaOfInterest = this.handleDrawAreaOfInterest.bind(this);
         this.handleCancelDrawing = this.handleCancelDrawing.bind(this);
+        this.disableRectangleTwoClickDrawing = this.disableRectangleTwoClickDrawing.bind(this);
     }
 
     componentDidMount() {
@@ -55,9 +58,17 @@ class OSMExtractionMap extends Component {
             this.handleDrawAreaOfInterest,
         );
 
+        leafletElement.on(
+            PRECLICK,
+            this.disableRectangleTwoClickDrawing,
+        );
+
         this.rectangleDrawHandler = new L.Draw.Rectangle(leafletElement, {
             shapeOptions: areaOfInterestStyle,
         });
+
+        this.rectangleDrawHandler._initialLabelText = // eslint-disable-line no-underscore-dangle
+            'Click and hold the mouse button down then drag to draw a rectangle.';
 
         this.polygonDrawHandler = new L.Draw.Polygon(leafletElement, {
             shapeOptions: areaOfInterestStyle,
@@ -116,6 +127,19 @@ class OSMExtractionMap extends Component {
         }
 
         return null;
+    }
+
+    disableRectangleTwoClickDrawing() {
+        /* eslint-disable no-underscore-dangle */
+        if (!this.rectangleDrawHandler._enabled ||
+            !this.rectangleDrawHandler._isCurrentlyTwoClickDrawing) {
+            return null;
+        }
+        /* eslint-enable no-underscore-dangle */
+
+        this.rectangleDrawHandler.disable();
+
+        return this.handleCancelDrawing();
     }
 
     handleDrawAreaOfInterest({ layer }) {


### PR DESCRIPTION
## Overview

This PR circumvents an IE-11 specific bug in Leaflet Draw whereby it
wasn't possible to draw a rectangle by clicking start and stop points.
To prevent it occuring, we disable that functionality and instead direct
users to click, hold the mouse button down, and drag to draw a
rectangle by updating the tooltip text shown when the rectangle draw
tool is active.

Although the bug didn't affect Chrome, to simplify things we also
disable two-click rectangle drawing there. Polygon drawing wasn't
impacted by the bug and is unaffected here.

Connects #24

### Demo

![drawtools](https://user-images.githubusercontent.com/4165523/43596566-a3cbc3a4-964d-11e8-9ec8-7d8c62ed097d.gif)

### Notes

As noted in #24 this quirk of Leaflet Draw is also present on their example site if used in IE11. It's potentially worth submitting an upstream patch but unlikely that it'd get merged anytime soon.

## Testing Instructions

- get this branch, then server and visit the site in both IE11 and Chrome
- verify that the polygon draw tool still works
- verify that the rectangle draw tool enables one-click-then-drag-then-release drawing and that the tooltip describes how to do that accurately
- verify that you can't recreate the bug described in #24 
- repeat steps above in IE11 and Chrome for the Netlify PR preview site generated below