### PR TITLE
Execute real overpass queries based on selection

### DIFF
--- a/src/js/src/actions.data.js
+++ b/src/js/src/actions.data.js
@@ -71,7 +71,7 @@ export function makeOverpassAPIRequest() {
             },
         })
             .then(({ data }) => osmtogeojson(data))
-            .then(data => downloadShapefile(data))
+            .then(data => downloadShapefile(data, dateRange, features))
             .then(data => dispatch(completeOverpassRequest(data)))
             .catch(e => dispatch(failOverpassRequest(e)));
     };

--- a/src/js/src/components/FeatureSelector.jsx
+++ b/src/js/src/components/FeatureSelector.jsx
@@ -5,14 +5,14 @@ import Select from 'react-select';
 
 import { selectFeatures } from '../actions.ui';
 
-import { featureOptions } from '../constants';
+import { featureConfig } from '../constants';
 
 function FeatureSelector({
     features,
     dispatch,
 }) {
     const handleSelectFeaturesChange = ({ value }) => dispatch(selectFeatures(value));
-
+    const options = featureConfig.map(({ label }) => ({ label, value: label }));
     return (
         <div className="select -feature">
             <div className="label">
@@ -23,7 +23,7 @@ function FeatureSelector({
                 name="feature-selector"
                 onChange={handleSelectFeaturesChange}
                 value={features}
-                options={featureOptions}
+                options={options}
                 clearable={false}
                 placeholder="Select a feature to extract..."
             />
@@ -36,7 +36,7 @@ FeatureSelector.defaultProps = {
 };
 
 FeatureSelector.propTypes = {
-    features: oneOf(featureOptions.map(({ value }) => value)),
+    features: oneOf(featureConfig.map(({ label }) => label)),
     dispatch: func.isRequired,
 };
 

--- a/src/js/src/constants.js
+++ b/src/js/src/constants.js
@@ -1,6 +1,8 @@
 import L from 'leaflet';
 import { arrayOf, bool, shape, string } from 'prop-types';
 
+export { default as featureConfig } from './featureConfig';
+
 export const basemapTilesUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 export const basemapAttribution =
     'Powered by <a href="https://esri.com">Esri</a> | &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>';
@@ -25,33 +27,6 @@ export const areaOfInterestStyle = {
     opacity: 1.0,
     weight: 3,
 };
-
-export const featureOptions = [
-    {
-        value: 'buildings',
-        label: 'Buildings',
-    },
-    {
-        value: 'emergencyInfraStructure',
-        label: 'Emergency infrastructure',
-    },
-    {
-        value: 'powerInfrastructure',
-        label: 'Power infrastructure',
-    },
-    {
-        value: 'roads',
-        label: 'Roads',
-    },
-    {
-        value: 'waterways',
-        label: 'Waterways',
-    },
-    {
-        value: 'airports',
-        label: 'Airports',
-    },
-];
 
 export const dateRangeOptions = [
     {

--- a/src/js/src/featureConfig.js
+++ b/src/js/src/featureConfig.js
@@ -1,0 +1,97 @@
+export default
+/*
+ * Configuration format for OSM features
+ */
+[
+    {
+        label: 'Buildings',
+        entities: [
+            {
+                tag: 'building',
+                values: ['residential', 'office'],
+            },
+        ],
+    },
+    {
+        label: 'Roads',
+        entities: [
+            {
+                tag: 'highway',
+                values: ['primary', 'secondary', 'tertiary'],
+            },
+        ],
+    },
+    {
+        label: 'Waterways',
+        entities: [
+            {
+                tag: 'waterway',
+                values: ['stream', 'river', 'riverbank', 'brook', 'rapids',
+                    'waterfall', 'pond', 'drystream', 'ditch', 'drain',
+                    'canal', 'dam', 'weir', 'lock_gate', 'artificial', 'dock',
+                    'boatyard', 'derelict_canal', 'lock', 'fishpass',
+                ],
+            },
+        ],
+    },
+    {
+        label: 'Amenities',
+        entities: [
+            {
+                tag: 'building',
+                values: ['school', 'hospital'],
+            },
+            {
+                tag: 'amenity',
+                values: ['school', 'place_of_worship', 'community_centre', 'hospital'],
+            },
+            {
+                tag: 'aeroway',
+                values: ['aerodrome'],
+            },
+        ],
+    },
+    {
+        label: 'Power Infrastructure',
+        entities: [
+            {
+                tag: 'power',
+                values: ['tower', 'line', 'generator'],
+            },
+        ],
+    },
+    {
+        label: 'Shop/Business',
+        entities: [
+            { tag: 'shop' },
+            { tag: 'office' },
+        ],
+    },
+    {
+        label: 'Financial Amenities',
+        entities: [
+            {
+                tag: 'amenity',
+                values: ['bank'],
+            },
+        ],
+    },
+    {
+        label: 'Public Transport',
+        entities: [
+            { tag: 'public_transport' },
+        ],
+    },
+    {
+        label: 'Leisure/Sport',
+        entities: [
+            { tag: 'sport' },
+        ],
+    },
+    {
+        label: 'Emergency Infrastructure',
+        entities: [
+            { tag: 'emergency' },
+        ],
+    },
+];

--- a/src/js/src/utils.js
+++ b/src/js/src/utils.js
@@ -72,17 +72,19 @@ function createShapefileName(/* dateRange */_, feature) {
  * @returns {object} Unmodified input geojson to use function in Promise chain
  */
 export function downloadShapefile(geojson, dateRange, feature) {
-    const folder = createShapefileName(dateRange, feature);
+    if (geojson.features.length) {
+        const folder = createShapefileName(dateRange, feature);
 
-    shpwrite.download(geojson, {
-        file: folder,
-        folder,
-        types: {
-            point: feature,
-            polygon: feature,
-            line: feature,
-        },
-    });
+        shpwrite.download(geojson, {
+            file: folder,
+            folder,
+            types: {
+                point: feature,
+                polygon: feature,
+                line: feature,
+            },
+        });
+    }
 
     return geojson;
 }


### PR DESCRIPTION
## Overview

Assembles the approved list of OSM features to a configuration file used to populate the FeatureSelect component, create a valid Overpass query and filename for download.

Connects #5 
Connects #10 

### Demo

![screenshot from 2018-12-06 18 18 50](https://user-images.githubusercontent.com/1014341/49617720-b9522300-f983-11e8-83b1-167f5f4e38bd.png)
![screenshot from 2018-12-06 18 18 28](https://user-images.githubusercontent.com/1014341/49617721-b9522300-f983-11e8-94c0-d60e2e4b7f02.png)

### Notes

This produces invalid shapefiles that can't be read by ArcMap and have variable luck being loaded in other tools like http://mapshaper.org.  The error tends to be a discrepancy between the count of features and the count of DBF records.  Upon visual inspection, the geojson produced as an intermediate output appears to be valid and consistent.  Follow up issue is #33.

## Testing Instructions
* Scan the config file for typos against the [master list](https://docs.google.com/spreadsheets/d/1XV3-YhYLksP-Bog_zb4e7bGm8Hxmil1bzpDYOh3S1yA/edit#gid=0)
* Try various exports that do and do not have query results
* Try Amenities which have multiple tag/value pairs
* Try Leisure/Sport which has only one tag and no values