### PR TITLE
Add date range to overpass query

### DIFF
--- a/src/js/src/constants.js
+++ b/src/js/src/constants.js
@@ -1,5 +1,6 @@
 import L from 'leaflet';
 import { arrayOf, bool, shape, string } from 'prop-types';
+import moment from 'moment';
 
 export { default as featureConfig } from './featureConfig';
 
@@ -28,24 +29,41 @@ export const areaOfInterestStyle = {
     weight: 3,
 };
 
-export const dateRangeOptions = [
-    {
+// Unfortunately, moment's built-in .toISOString method isn't formatted in the
+// way the Overpass API expects -- so we format it here.
+const overpassDateFormat = 'YYYY-MM-DDThh:mm:ss';
+
+export const dateRangeOptions = Object.freeze([
+    Object.freeze({
         value: 'all',
         label: 'All',
-    },
-    {
+        dateSelection: null,
+    }),
+    Object.freeze({
         value: 'pastMonth',
         label: 'Past month',
-    },
-    {
+        dateSelection: moment()
+            .subtract(1, 'months')
+            .format(overpassDateFormat)
+            .concat('Z'),
+    }),
+    Object.freeze({
         value: 'pastThreeMonths',
         label: 'Past 3 months',
-    },
-    {
+        dateSelection: moment()
+            .subtract(3, 'months')
+            .format(overpassDateFormat)
+            .concat('Z'),
+    }),
+    Object.freeze({
         value: 'pastYear',
         label: 'Past year',
-    },
-];
+        dateSelection: moment()
+            .subtract(1, 'years')
+            .format(overpassDateFormat)
+            .concat('Z'),
+    }),
+]);
 
 export const overpassAPIurl = 'https://overpass-api.de/api/interpreter';
 

--- a/src/package.json
+++ b/src/package.json
@@ -25,6 +25,7 @@
     "esri-leaflet-geocoder": "~2.2.13",
     "leaflet": "~1.3.1",
     "leaflet-draw": "~0.4.14",
+    "moment": "2.22.2",
     "osmtogeojson": "2.2.12",
     "prop-types": "~15.6.1",
     "react": "~16.3.1",

--- a/src/sass/geocoder.scss
+++ b/src/sass/geocoder.scss
@@ -90,7 +90,7 @@
             justify-items: stretch;
 
             > .coordinate {
-                width: 50%;
+                width: 45%;
                 border: none;
                 font-size: 1rem;
                 font-family: $font-family;

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -5174,6 +5174,10 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
+moment@2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
## Overview

Although the UI had a date range dropdown, making a selection there previously did not change the overpass query. This PR adjusts things such that selecting one of the date range options will change the query using the `newer` option:

https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#newer

I brought in the momentjs library to handle structuring the dates more easily and ensure they would work on different browsers. Unfortunately, however, its `toISOString` method did not output exactly the format expected by Overpass -- so the code here manually formats it.

Connects #38

### Notes

First commit here fixes a minor style issue whereby the geocoder coordinate inputs would overextend their horizontal bounds. Glance at the coordinate inputs to verify that they no longer do.

## Testing Instructions

- get this branch, then `./scripts/update`
- visit the app, select a bbox, then select "Amenties" and click "Extract"
- verify that data returns
- with the same bbox, select "Amenities" and try out each of the date range options in the dropdown, verifying that each of them returns results and that the visual set of results differs slightly for each date range period.
