### PR TITLE
adds additional keys and values

### DIFF
--- a/src/js/src/featureConfig.js
+++ b/src/js/src/featureConfig.js
@@ -8,7 +8,7 @@ export default
         entities: [
             {
                 tag: 'building',
-                values: ['residential', 'office', 'yes', 'house', 'warehouse', 'public', 'service', 'construction'],
+                values: ['residential', 'office', 'yes', 'house', 'warehouse', 'public', 'service', 'construction', 'shed'],
             },
         ],
     },
@@ -17,7 +17,7 @@ export default
         entities: [
             {
                 tag: 'highway',
-                values: ['primary', 'secondary', 'tertiary', 'residential'],
+                values: ['primary', 'secondary', 'tertiary', 'residential', 'unclassified'],
             },
         ],
     },

--- a/src/js/src/featureConfig.js
+++ b/src/js/src/featureConfig.js
@@ -68,13 +68,15 @@ export default
         label: 'Shop/Business',
         entities: [
             { tag: 'shop' },
-            { tag: 'craft'},
+            { tag: 'craft' },
             { tag: 'office' },
-            { tag: 'building',
-              values: ['office'],
+            {
+                tag: 'building',
+                values: ['office'],
             },
-            { tag: 'amenity',
-              values: ['restaurant', 'cafe', 'bar', 'biergarten', 'fast_food', 'marketplace', 'fuel'],
+            {
+                tag: 'amenity',
+                values: ['restaurant', 'cafe', 'internet_cafe', 'bar', 'biergarten', 'fast_food', 'marketplace', 'fuel'],
             },
         ],
     },
@@ -92,12 +94,12 @@ export default
         entities: [
             { tag: 'public_transport' },
             {
-              tag: 'amenity',
-              values: ['bus_station'],
+                tag: 'amenity',
+                values: ['bus_station'],
             },
             {
-              tag: 'highway',
-              values: ['bus_stop'],
+                tag: 'highway',
+                values: ['bus_stop'],
             },
         ],
     },
@@ -106,9 +108,10 @@ export default
         entities: [
             { tag: 'sport' },
             { tag: 'leisure' },
-            { tag: 'landuse',
-              values: ['recreation_ground'],
-           },
+            {
+                tag: 'landuse',
+                values: ['recreation_ground'],
+            },
         ],
     },
     {

--- a/src/js/src/featureConfig.js
+++ b/src/js/src/featureConfig.js
@@ -8,7 +8,7 @@ export default
         entities: [
             {
                 tag: 'building',
-                values: ['residential', 'office'],
+                values: ['residential', 'office', 'yes', 'house', 'warehouse', 'public', 'service', 'construction'],
             },
         ],
     },
@@ -17,7 +17,7 @@ export default
         entities: [
             {
                 tag: 'highway',
-                values: ['primary', 'secondary', 'tertiary'],
+                values: ['primary', 'secondary', 'tertiary', 'residential'],
             },
         ],
     },
@@ -39,11 +39,15 @@ export default
         entities: [
             {
                 tag: 'building',
-                values: ['school', 'hospital'],
+                values: ['school', 'hospital', 'church', 'hotel'],
+            },
+            {
+                tag: 'tourism',
+                values: ['hotel', 'museum'],
             },
             {
                 tag: 'amenity',
-                values: ['school', 'place_of_worship', 'community_centre', 'hospital'],
+                values: ['school', 'place_of_worship', 'community_centre', 'hospital', 'library'],
             },
             {
                 tag: 'aeroway',
@@ -64,7 +68,14 @@ export default
         label: 'Shop/Business',
         entities: [
             { tag: 'shop' },
+            { tag: 'craft'},
             { tag: 'office' },
+            { tag: 'building',
+              values: ['office'],
+            },
+            { tag: 'amenity',
+              values: ['restaurant', 'cafe', 'bar', 'biergarten', 'fast_food', 'marketplace', 'fuel'],
+            },
         ],
     },
     {
@@ -72,7 +83,7 @@ export default
         entities: [
             {
                 tag: 'amenity',
-                values: ['bank'],
+                values: ['bank', 'atm'],
             },
         ],
     },
@@ -80,12 +91,24 @@ export default
         label: 'Public Transport',
         entities: [
             { tag: 'public_transport' },
+            {
+              tag: 'amenity',
+              values: ['bus_station'],
+            },
+            {
+              tag: 'highway',
+              values: ['bus_stop'],
+            },
         ],
     },
     {
         label: 'Leisure/Sport',
         entities: [
             { tag: 'sport' },
+            { tag: 'leisure' },
+            { tag: 'landuse',
+              values: ['recreation_ground'],
+           },
         ],
     },
     {


### PR DESCRIPTION

## Overview

 Adds additional keys and values for the following labels: 

- buildings
- roads
- amenities
- shops/business
- financial amenities
- public transport
- leisure sport

Changes were made by comparing queries from the tool with data pulled using JOSM and querying individual features in OSM.

### Notes

Some labels will result in queries that select the same feature. For example, selecting `Buildings` and then `Amenities` may result in the same feature being selected in both queries because it has tags that apply to both. I don't think there is any way around this, especially because the `building=yes` tag is so broad but required for most building polygons.

