### PR TITLE
Small improvements

### DIFF
--- a/src/js/src/components/ExtractButton.jsx
+++ b/src/js/src/components/ExtractButton.jsx
@@ -7,10 +7,12 @@ import { makeOverpassAPIRequest } from '../actions.data';
 function ExtractButton({
     dispatch,
     disabled,
+    fetching,
 }) {
     const buttonClassName = disabled ?
         'button -extract -disabled' :
         'button -extract';
+    const text = fetching ? 'LOADING...' : 'EXTRACT';
 
     return (
         <button
@@ -19,7 +21,7 @@ function ExtractButton({
             onClick={() => dispatch(makeOverpassAPIRequest())}
             disabled={disabled}
         >
-            EXTRACT
+            {text}
         </button>
     );
 }
@@ -27,6 +29,7 @@ function ExtractButton({
 ExtractButton.propTypes = {
     dispatch: func.isRequired,
     disabled: bool.isRequired,
+    fetching: bool.isRequired,
 };
 
 function mapStateToProps({
@@ -46,6 +49,7 @@ function mapStateToProps({
 }) {
     return {
         disabled: fetching || !drawnShape || !features,
+        fetching,
     };
 }
 

--- a/src/js/src/components/OSMExtractionMap.jsx
+++ b/src/js/src/components/OSMExtractionMap.jsx
@@ -208,6 +208,7 @@ class OSMExtractionMap extends Component {
                 center={initialMapCenter}
                 zoom={initialMapZoom}
                 zoomControl={false}
+                renderer={L.canvas()}
             >
                 <TileLayer
                     url={basemapTilesUrl}

--- a/src/js/src/constants.js
+++ b/src/js/src/constants.js
@@ -12,10 +12,10 @@ export const basemapMaxZoom = 19;
 export const osmUrl = 'https://www.openstreetmap.org/edit?editor=id#map=';
 
 export const initialMapCenter = [
-    6.7922,
-    -58.1127,
+    6.8022,
+    -58.1427,
 ];
-export const initialMapZoom = 13;
+export const initialMapZoom = 14;
 
 export const drawToolTypeEnum = {
     box: 'box',


### PR DESCRIPTION
## Overview

A few easy improvements as I'm creating artifacts for the training workshop:

- Use `canvas` renderer for improved performance when rendering many features
- Indicate loading status
- Initialize map at high zoom level to encourage smaller AoIs

See commits for detailed messages.

Connects https://github.com/azavea/civic-apps/issues/353

## Testing Instructions

 * Compare rendering of modestly sized urban area of Georgetown between this branch and production. Note that is uses canvas and can render more features, though querying, downloading and parsing is still a significant effort.
 * While the app is fetching, the button text turns to "Loading..." and reverts to "Extract" under all other conditions
 * Map is zoomed in closer, but also captures downtown Georgetown