### PR TITLE
Include all building tags

### DIFF
--- a/src/js/src/featureConfig.js
+++ b/src/js/src/featureConfig.js
@@ -6,10 +6,7 @@ export default
     {
         label: 'Buildings',
         entities: [
-            {
-                tag: 'building',
-                values: ['residential', 'office', 'yes', 'house', 'warehouse', 'public', 'service', 'construction', 'shed'],
-            },
+            { tag: 'building' },
         ],
     },
     {


### PR DESCRIPTION
## Overview

Some prominent features were left out, including `commercial`.

## Demo
### Before
Note, for example, the Mariott hotel was unselected before this change
![image](https://user-images.githubusercontent.com/1014341/56170458-9843b380-5faf-11e9-9b4a-3b33542d9b50.png)

### After
![image](https://user-images.githubusercontent.com/1014341/56170411-6df1f600-5faf-11e9-981e-7a49bab10196.png)

## Testing Instructions

This PR: https://deploy-preview-51--idb-osm-extraction-tool.netlify.com/
Production: https://idb-osm-extraction-tool.netlify.com/

 * Compare this branch building extraction to production/staging
